### PR TITLE
Fix from_cube ignoring grid origin (#4607)

### DIFF
--- a/src/pymatgen/io/common.py
+++ b/src/pymatgen/io/common.py
@@ -405,7 +405,10 @@ class VolumetricData(MSONable):
             lines = f.readlines()
 
         # Parse the number of atoms from line 3 (first two lines are headers)
-        n_atoms = int(lines[2].split()[0])
+        # Format: n_atoms origin_x origin_y origin_z
+        header = lines[2].split()
+        n_atoms = int(header[0])
+        origin = np.array(header[1:4], dtype=float) * bohr_to_angstrom
 
         # Pre-parse voxel data into arrays
         def parse_voxel(line):
@@ -422,7 +425,7 @@ class VolumetricData(MSONable):
         atom_data_start = 6
         atom_data_end = atom_data_start + n_atoms
         sites = [
-            Site(line.split()[0], np.array(line.split()[2:], dtype=float) * bohr_to_angstrom)  # type:ignore[arg-type]
+            Site(line.split()[0], np.array(line.split()[2:], dtype=float) * bohr_to_angstrom - origin) # type:ignore[arg-type]
             for line in lines[atom_data_start:atom_data_end]
         ]
 

--- a/tests/io/test_common.py
+++ b/tests/io/test_common.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import numpy as np
 import pytest
 
 from pymatgen.io.common import PMGDir, VolumetricData
@@ -23,7 +24,17 @@ def test_cube_io_faithful(tmp_path: Path) -> None:
     assert cube_file.structure.volume == out_cube.structure.volume
     assert cube_file.structure == out_cube.structure
 
+def test_cube_nonzero_origin() -> None:
+    """Regression test for gh-4607: from_cube must account for the grid origin on line 3."""
+    vd = VolumetricData.from_cube(f"{TEST_FILES_DIR}/electronic_structure/boltztrap/fermi/boltztrap_BZ.cube")
 
+    assert len(vd.structure) == 96
+    assert str(vd.structure[0].specie) == "Fe"
+    np.testing.assert_allclose(
+        vd.structure[0].frac_coords,
+        [0.16528953, 0.6611559, 0.24615391],
+        atol=1e-6,
+    )
 class TestPMGDir:
     def test_getitem(self):
         # Some simple testing of loading and reading since all these were tested in other classes.


### PR DESCRIPTION
## Summary
Fixes #4607

`VolumetricData.from_cube` parses line 3 of a cube file for the atom count, but discards the grid origin also present on that line (`n_atoms  origin_x  origin_y  origin_z`). Atom coordinates were then used as-is, so any cube file with a nonzero origin produced an incorrectly positioned `Structure`.

Fix:
- `from_cube` now parses the origin and subtracts it from atom coordinates, so they're placed relative to the first grid voxel
  `(0, 0, 0)`.

## Todos
None — fix is complete.

## Checklist
- [x] Google format doc strings added. Check with `ruff`.
- [x] Type annotations included. Check with `mypy`.
- [x] Tests added for new features/fixes.
- [ ] If applicable, new classes/functions/modules have `duecredit` `@due.dcite` decorators to reference relevant papers by DOI (not applicable — bug fix, no new citable methodology)