### PR TITLE
Change handling of standard cells in SpacegroupAnalyzer

### DIFF
--- a/src/pymatgen/core/structure.py
+++ b/src/pymatgen/core/structure.py
@@ -4741,7 +4741,7 @@ class Structure(IStructure, collections.abc.MutableSequence):
         """Rapidly construct common prototype structures.
 
         Args:
-            prototype: Name of prototype. e.g. cubic, rocksalt, perovksite etc.
+            prototype: Name of prototype. e.g. cubic, rocksalt, perovskite etc.
             species: List of species corresponding to symmetrically distinct sites.
             **kwargs: Lattice parameters, e.g. a = 3.0, b = 4, c = 5. Only the required lattice parameters need to be
                 specified. For example, if it is a cubic prototype, only a needs to be specified.

--- a/src/pymatgen/symmetry/analyzer.py
+++ b/src/pymatgen/symmetry/analyzer.py
@@ -699,9 +699,8 @@ class SpacegroupAnalyzer:
                 for idx in range(2):
                     transf[idx][sorted_dic[idx]["orig_index"]] = 1
                 c = lattice.abc[2]
-            elif self.get_space_group_symbol().startswith(
-                "A"
-            ):  # change to C-centering to match Setyawan/Curtarolo convention
+            # change to C-centering to match Setyawan/Curtarolo convention
+            elif self.get_space_group_symbol().startswith("A"):
                 transf[2] = [1, 0, 0]
                 a, b = sorted(lattice.abc[1:])
                 sorted_dic = sorted(
@@ -743,10 +742,13 @@ class SpacegroupAnalyzer:
             # check first if we have the refined structure shows a rhombohedral
             # cell
             # if so, make a supercell
-            a, b, c = lattice.abc
-            if np.all(np.abs([a - b, c - b, a - c]) < 0.001):
+            if np.allclose(lattice.abc, lattice.a, atol=1e-3, rtol=0.0) and np.allclose(
+                lattice.angles, lattice.alpha, atol=1e-2, rtol=0.0
+            ):
                 struct.make_supercell(((1, -1, 0), (0, 1, -1), (1, 1, 1)))
                 a, b, c = sorted(struct.lattice.abc)
+            else:
+                a, b, c = lattice.abc
 
             if abs(b - c) < 0.001:
                 a, c = c, a
@@ -755,7 +757,6 @@ class SpacegroupAnalyzer:
                 [a / 2, a * math.sqrt(3) / 2, 0],
                 [0, 0, c],
             ]
-            lattice = Lattice(new_matrix)
             transf = np.eye(3, dtype=np.float64)  # type:ignore[assignment]
 
         elif latt_type == "monoclinic":

--- a/src/pymatgen/symmetry/analyzer.py
+++ b/src/pymatgen/symmetry/analyzer.py
@@ -775,7 +775,7 @@ class SpacegroupAnalyzer:
                 b = sorted_dic[1]["length"]
                 c = lattice.abc[2]
                 new_matrix = None
-                for tp2 in itertools.permutations(list(range(2)), 2):
+                for tp2 in itertools.permutations(range(2), 2):
                     m = lattice.matrix
                     latt2 = Lattice([m[tp2[0]], m[tp2[1]], m[2]])
                     lengths = latt2.lengths
@@ -819,7 +819,7 @@ class SpacegroupAnalyzer:
                 # keep the ones with the non-90 angle=alpha and b<c
                 new_matrix = None
 
-                for tp3 in itertools.permutations(list(range(3)), 3):
+                for tp3 in itertools.permutations(range(3), 3):
                     m = lattice.matrix
                     a, b, c, alpha, beta, gamma = Lattice([m[tp3[0]], m[tp3[1]], m[tp3[2]]]).parameters
                     if alpha == 90 or b >= c:

--- a/src/pymatgen/symmetry/analyzer.py
+++ b/src/pymatgen/symmetry/analyzer.py
@@ -235,7 +235,7 @@ class SpacegroupAnalyzer:
 
     def get_lattice_type(self) -> LatticeType:
         """Get the lattice for the structure, e.g. (triclinic, orthorhombic, cubic,
-        etc.).This is the same as the crystal system with the exception of the
+        etc.). This is the same as the crystal system with the exception of the
         hexagonal/rhombohedral lattice.
 
         Raises:
@@ -533,8 +533,8 @@ class SpacegroupAnalyzer:
             conv_lattice = conv.lattice
         lattype = self.get_lattice_type()
 
-        if "P" in self.get_space_group_symbol() or lattype == "hexagonal":
-            return np.eye(3)
+        if self.get_space_group_symbol().startswith("P"):
+            return np.eye(3, dtype=np.float64)
 
         if lattype == "rhombohedral":
             # Check if the conventional representation is hexagonal or
@@ -543,18 +543,18 @@ class SpacegroupAnalyzer:
                 return np.eye(3)
             return np.array([[-1, 1, 1], [2, 1, 1], [-1, -2, 1]], dtype=np.float64) / 3
 
-        if "I" in self.get_space_group_symbol():
+        if self.get_space_group_symbol().startswith("I"):
             return np.array([[-1, 1, 1], [1, -1, 1], [1, 1, -1]], dtype=np.float64) / 2
 
-        if "F" in self.get_space_group_symbol():
+        if self.get_space_group_symbol().startswith("F"):
             return np.array([[0, 1, 1], [1, 0, 1], [1, 1, 0]], dtype=np.float64) / 2
 
-        if "C" in self.get_space_group_symbol() or "A" in self.get_space_group_symbol():
+        if self.get_space_group_symbol().startswith(("C", "A")):
             if self.get_crystal_system() == "monoclinic":
                 return np.array([[1, 1, 0], [-1, 1, 0], [0, 0, 2]], dtype=np.float64) / 2
             return np.array([[1, -1, 0], [1, 1, 0], [0, 0, 2]], dtype=np.float64) / 2
 
-        return np.eye(3)
+        return np.eye(3, dtype=np.float64)
 
     @cite_conventional_cell_algo
     def get_primitive_standard_structure(
@@ -588,7 +588,7 @@ class SpacegroupAnalyzer:
         )
         lattype = self.get_lattice_type()
 
-        if self.get_space_group_symbol().startswith("P") or lattype == "hexagonal":
+        if self.get_space_group_symbol().startswith("P"):
             return conv
 
         transf = self.get_conventional_to_primitive_transformation_matrix(

--- a/src/pymatgen/symmetry/analyzer.py
+++ b/src/pymatgen/symmetry/analyzer.py
@@ -591,30 +591,23 @@ class SpacegroupAnalyzer:
             international_monoclinic=international_monoclinic
         )
 
-        prim_lattice = Lattice(transf @ conv.lattice.matrix)
-
-        # Create primitive sites
-        prim_sites: list[PeriodicSite] = []
-        seen: set[tuple[float, float, float]] = set()
-
+        new_sites: list[PeriodicSite] = []
+        lattice = Lattice(transf @ conv.lattice.matrix)
         for site in conv:
-            s = PeriodicSite(
+            new_s = PeriodicSite(
                 site.species,
                 site.coords,
-                prim_lattice,
+                lattice,
                 to_unit_cell=True,
                 coords_are_cartesian=True,
                 properties=site.properties,
             )
-            key = tuple(np.round(np.mod(s.frac_coords, 1.0), 8))
-            if key not in seen:
-                seen.add(key)
-                prim_sites.append(s)
+            if not any(map(new_s.is_periodic_image, new_sites)):
+                new_sites.append(new_s)
 
-        # Standardize rhombohedral cell
         if self.get_lattice_type() == "rhombohedral":
-            a = prim_lattice.a
-            alpha = math.radians(prim_lattice.alpha)
+            a = lattice.a
+            alpha = math.radians(lattice.alpha)
             new_matrix = [
                 [a * cos(alpha / 2), -a * sin(alpha / 2), 0],
                 [a * cos(alpha / 2), a * sin(alpha / 2), 0],
@@ -624,20 +617,21 @@ class SpacegroupAnalyzer:
                     a * math.sqrt(1 - (cos(alpha) ** 2 / (cos(alpha / 2) ** 2))),
                 ],
             ]
-            rhom_lattice = Lattice(new_matrix)
-
-            prim_sites = [
-                PeriodicSite(
+            rhomb_sites = []
+            lattice = Lattice(new_matrix)
+            for site in new_sites:
+                new_s = PeriodicSite(
                     site.species,
                     site.frac_coords,
-                    rhom_lattice,
+                    lattice,
                     to_unit_cell=True,
                     properties=site.properties,
                 )
-                for site in prim_sites
-            ]
+                if not any(map(new_s.is_periodic_image, new_sites)):
+                    rhomb_sites.append(new_s)
+            new_sites = rhomb_sites
 
-        return Structure.from_sites(prim_sites)
+        return Structure.from_sites(new_sites)
 
     @cite_conventional_cell_algo
     def get_conventional_standard_structure(

--- a/src/pymatgen/symmetry/analyzer.py
+++ b/src/pymatgen/symmetry/analyzer.py
@@ -583,7 +583,6 @@ class SpacegroupAnalyzer:
             international_monoclinic=international_monoclinic,
             keep_site_properties=keep_site_properties,
         )
-        lattype = self.get_lattice_type()
 
         if self.get_space_group_symbol().startswith("P"):
             return conv
@@ -592,23 +591,30 @@ class SpacegroupAnalyzer:
             international_monoclinic=international_monoclinic
         )
 
-        new_sites: list[PeriodicSite] = []
-        lattice = Lattice(transf @ conv.lattice.matrix)
+        prim_lattice = Lattice(transf @ conv.lattice.matrix)
+
+        # Create primitive sites
+        prim_sites: list[PeriodicSite] = []
+        seen: set[tuple[float, float, float]] = set()
+
         for site in conv:
-            new_s = PeriodicSite(
+            s = PeriodicSite(
                 site.species,
                 site.coords,
-                lattice,
+                prim_lattice,
                 to_unit_cell=True,
                 coords_are_cartesian=True,
                 properties=site.properties,
             )
-            if not any(map(new_s.is_periodic_image, new_sites)):
-                new_sites.append(new_s)
+            key = tuple(np.round(np.mod(s.frac_coords, 1.0), 8))
+            if key not in seen:
+                seen.add(key)
+                prim_sites.append(s)
 
-        if lattype == "rhombohedral":
-            a = lattice.a
-            alpha = math.radians(lattice.alpha)
+        # Standardize rhombohedral cell
+        if self.get_lattice_type() == "rhombohedral":
+            a = prim_lattice.a
+            alpha = math.radians(prim_lattice.alpha)
             new_matrix = [
                 [a * cos(alpha / 2), -a * sin(alpha / 2), 0],
                 [a * cos(alpha / 2), a * sin(alpha / 2), 0],
@@ -618,22 +624,20 @@ class SpacegroupAnalyzer:
                     a * math.sqrt(1 - (cos(alpha) ** 2 / (cos(alpha / 2) ** 2))),
                 ],
             ]
-            rhomb_sites: list[PeriodicSite] = []
-            lattice = Lattice(new_matrix)
-            for site in new_sites:
-                new_s = PeriodicSite(
+            rhom_lattice = Lattice(new_matrix)
+
+            prim_sites = [
+                PeriodicSite(
                     site.species,
-                    site.coords,
-                    lattice,
+                    site.frac_coords,
+                    rhom_lattice,
                     to_unit_cell=True,
-                    coords_are_cartesian=True,
                     properties=site.properties,
                 )
-                if not any(map(new_s.is_periodic_image, new_sites)):
-                    rhomb_sites.append(new_s)
-            new_sites = rhomb_sites
+                for site in prim_sites
+            ]
 
-        return Structure.from_sites(new_sites)
+        return Structure.from_sites(prim_sites)
 
     @cite_conventional_cell_algo
     def get_conventional_standard_structure(

--- a/src/pymatgen/symmetry/analyzer.py
+++ b/src/pymatgen/symmetry/analyzer.py
@@ -606,7 +606,7 @@ class SpacegroupAnalyzer:
             if not any(map(new_s.is_periodic_image, new_sites)):
                 new_sites.append(new_s)
 
-        if lattice == "rhombohedral":
+        if lattype == "rhombohedral":
             prim = Structure.from_sites(new_sites)
             lengths = prim.lattice.lengths
             angles = prim.lattice.angles

--- a/src/pymatgen/symmetry/analyzer.py
+++ b/src/pymatgen/symmetry/analyzer.py
@@ -466,8 +466,8 @@ class SpacegroupAnalyzer:
         Args:
             mesh (3x1 array): The number of kpoint for the mesh needed in
                 each direction
-            is_shift (3x1 array): Whether to shift the kpoint grid. (1, 1,
-            1) means all points are shifted by 0.5, 0.5, 0.5.
+            is_shift (3x1 array): Whether to shift the kpoint grid. (1, 1, 1)
+                means all points are shifted by 0.5, 0.5, 0.5.
 
         Returns:
             A list of irreducible kpoints and their weights as a list of
@@ -493,8 +493,8 @@ class SpacegroupAnalyzer:
         Args:
             mesh (3x1 array): The number of kpoint for the mesh needed in
                 each direction
-            is_shift (3x1 array): Whether to shift the kpoint grid. (1, 1,
-            1) means all points are shifted by 0.5, 0.5, 0.5.
+            is_shift (3x1 array): Whether to shift the kpoint grid. (1, 1, 1)
+                means all points are shifted by 0.5, 0.5, 0.5.
 
         Returns:
             A tuple containing two numpy.ndarray. The first is the mesh in

--- a/src/pymatgen/symmetry/analyzer.py
+++ b/src/pymatgen/symmetry/analyzer.py
@@ -757,6 +757,7 @@ class SpacegroupAnalyzer:
                 [a / 2, a * math.sqrt(3) / 2, 0],
                 [0, 0, c],
             ]
+            lattice = Lattice(new_matrix)
             transf = np.eye(3, dtype=np.float64)  # type:ignore[assignment]
 
         elif latt_type == "monoclinic":
@@ -785,7 +786,7 @@ class SpacegroupAnalyzer:
                     lengths = latt2.lengths
                     angles = latt2.angles
                     alpha_degrees = angles[0]
-                    if alpha_degrees == 90:
+                    if math.isclose(alpha_degrees, 90, rel_tol=0, abs_tol=1e-10):
                         continue
 
                     transf = np.zeros(shape=(3, 3))
@@ -826,7 +827,7 @@ class SpacegroupAnalyzer:
                 for tp3 in itertools.permutations(range(3), 3):
                     m = lattice.matrix
                     a, b, c, alpha, beta, gamma = Lattice([m[tp3[0]], m[tp3[1]], m[tp3[2]]]).parameters
-                    if alpha == 90 or b >= c:
+                    if math.isclose(alpha, 90, rel_tol=0, abs_tol=1e-10) or b >= c:
                         continue
                     transf = np.zeros(shape=(3, 3))
                     transf[2][tp3[2]] = 1

--- a/src/pymatgen/symmetry/analyzer.py
+++ b/src/pymatgen/symmetry/analyzer.py
@@ -511,8 +511,7 @@ class SpacegroupAnalyzer:
     @cite_conventional_cell_algo
     def get_conventional_to_primitive_transformation_matrix(
         self,
-        international_monoclinic: bool = True,
-        conv_lattice: Lattice | None = None,
+        international_monoclinic: bool,
     ) -> NDArray:
         """Get the transformation matrix to transform a conventional unit cell to a
         primitive cell according to certain standards. The standards are defined in
@@ -522,16 +521,15 @@ class SpacegroupAnalyzer:
 
         Args:
             international_monoclinic (bool): Whether to convert to proper international convention
-                such that beta is the non-right angle.
-            conv_lattice (Lattice): Conventional Lattice of the structure, if known.
+                such that beta is the non-right angle. Unused.
 
         Returns:
-            Transformation matrix to go from conventional to primitive cell
-        """
-        if conv_lattice is None:
-            conv = self.get_conventional_standard_structure(international_monoclinic=international_monoclinic)
-            conv_lattice = conv.lattice
+            Transformation matrix to go from conventional to primitive cell.
 
+        Notes:
+            Note that for face-centered space groups (C-/A-centered), standardization to C-centering
+            is expected. Therefore, the transformation matrix C->P is returned.
+        """
         space_group = self.get_space_group_symbol()
 
         if space_group.startswith("P"):
@@ -546,13 +544,12 @@ class SpacegroupAnalyzer:
         if space_group.startswith("F"):
             return np.array([[0, 1, 1], [1, 0, 1], [1, 1, 0]], dtype=np.float64) / 2
 
-        if space_group.startswith("C"):
+        # Convert face-centered cell. Note that this converts a C-centered cell,
+        # A-centered cells must be standardized to them beforehand.
+        if space_group.startswith(("C", "A")):
             if self.get_crystal_system() == "monoclinic":
                 return np.array([[1, 1, 0], [-1, 1, 0], [0, 0, 2]], dtype=np.float64) / 2
             return np.array([[1, -1, 0], [1, 1, 0], [0, 0, 2]], dtype=np.float64) / 2
-
-        if space_group.startswith("A"):
-            return np.array([[2, 0, 0], [0, 1, 1], [0, -1, 1]], dtype=np.float64) / 2
 
         raise ValueError(f"Unrecognized space group {space_group}.")
 
@@ -592,11 +589,11 @@ class SpacegroupAnalyzer:
             return conv
 
         transf = self.get_conventional_to_primitive_transformation_matrix(
-            international_monoclinic=international_monoclinic, conv_lattice=conv.lattice
+            international_monoclinic=international_monoclinic
         )
 
         new_sites: list[PeriodicSite] = []
-        lattice = Lattice(np.dot(transf, conv.lattice.matrix))
+        lattice = Lattice(transf @ conv.lattice.matrix)
         for site in conv:
             new_s = PeriodicSite(
                 site.species,
@@ -610,11 +607,8 @@ class SpacegroupAnalyzer:
                 new_sites.append(new_s)
 
         if lattype == "rhombohedral":
-            prim = Structure.from_sites(new_sites)
-            lengths = prim.lattice.lengths
-            angles = prim.lattice.angles
-            a = lengths[0]
-            alpha = math.radians(angles[0])
+            a = lattice.a
+            alpha = math.radians(lattice.alpha)
             new_matrix = [
                 [a * cos(alpha / 2), -a * sin(alpha / 2), 0],
                 [a * cos(alpha / 2), a * sin(alpha / 2), 0],
@@ -624,18 +618,20 @@ class SpacegroupAnalyzer:
                     a * math.sqrt(1 - (cos(alpha) ** 2 / (cos(alpha / 2) ** 2))),
                 ],
             ]
-            new_sites = []
+            rhomb_sites: list[PeriodicSite] = []
             lattice = Lattice(new_matrix)
-            for site in prim:
+            for site in new_sites:
                 new_s = PeriodicSite(
                     site.species,
-                    site.frac_coords,
+                    site.coords,
                     lattice,
                     to_unit_cell=True,
+                    coords_are_cartesian=True,
                     properties=site.properties,
                 )
                 if not any(map(new_s.is_periodic_image, new_sites)):
                     new_sites.append(new_s)
+            new_sites = rhomb_sites
 
         return Structure.from_sites(new_sites)
 

--- a/src/pymatgen/symmetry/analyzer.py
+++ b/src/pymatgen/symmetry/analyzer.py
@@ -585,7 +585,7 @@ class SpacegroupAnalyzer:
         )
         lattype = self.get_lattice_type()
 
-        if "P" in self.get_space_group_symbol() or lattype == "hexagonal":
+        if self.get_space_group_symbol().startswith("P") or lattype == "hexagonal":
             return conv
 
         transf = self.get_conventional_to_primitive_transformation_matrix(
@@ -625,7 +625,7 @@ class SpacegroupAnalyzer:
             lattice = Lattice(new_matrix)
             for site in prim:
                 new_s = PeriodicSite(
-                    site.specie,
+                    site.species,
                     site.frac_coords,
                     lattice,
                     to_unit_cell=True,

--- a/src/pymatgen/symmetry/analyzer.py
+++ b/src/pymatgen/symmetry/analyzer.py
@@ -512,6 +512,7 @@ class SpacegroupAnalyzer:
     def get_conventional_to_primitive_transformation_matrix(
         self,
         international_monoclinic: bool = True,
+        conv_lattice: Lattice | None = None,
     ) -> NDArray:
         """Get the transformation matrix to transform a conventional unit cell to a
         primitive cell according to certain standards. The standards are defined in
@@ -522,11 +523,14 @@ class SpacegroupAnalyzer:
         Args:
             international_monoclinic (bool): Whether to convert to proper international convention
                 such that beta is the non-right angle.
+            conv_lattice (Lattice): Conventional Lattice of the structure, if known.
 
         Returns:
             Transformation matrix to go from conventional to primitive cell
         """
-        conv = self.get_conventional_standard_structure(international_monoclinic=international_monoclinic)
+        if conv_lattice is None:
+            conv = self.get_conventional_standard_structure(international_monoclinic=international_monoclinic)
+            conv_lattice = conv.lattice
         lattype = self.get_lattice_type()
 
         if "P" in self.get_space_group_symbol() or lattype == "hexagonal":
@@ -535,8 +539,7 @@ class SpacegroupAnalyzer:
         if lattype == "rhombohedral":
             # Check if the conventional representation is hexagonal or
             # rhombohedral
-            lengths = conv.lattice.lengths
-            if abs(lengths[0] - lengths[2]) < 1e-4:
+            if abs(conv_lattice.lengths[0] - conv_lattice.lengths[2]) < 1e-4:
                 return np.eye(3)
             return np.array([[-1, 1, 1], [2, 1, 1], [-1, -2, 1]], dtype=np.float64) / 3
 
@@ -589,7 +592,7 @@ class SpacegroupAnalyzer:
             return conv
 
         transf = self.get_conventional_to_primitive_transformation_matrix(
-            international_monoclinic=international_monoclinic
+            international_monoclinic=international_monoclinic, conv_lattice=conv.lattice
         )
 
         new_sites: list[PeriodicSite] = []
@@ -611,7 +614,7 @@ class SpacegroupAnalyzer:
             lengths = prim.lattice.lengths
             angles = prim.lattice.angles
             a = lengths[0]
-            alpha = math.pi * angles[0] / 180
+            alpha = math.radians(angles[0])
             new_matrix = [
                 [a * cos(alpha / 2), -a * sin(alpha / 2), 0],
                 [a * cos(alpha / 2), a * sin(alpha / 2), 0],

--- a/src/pymatgen/symmetry/analyzer.py
+++ b/src/pymatgen/symmetry/analyzer.py
@@ -630,7 +630,7 @@ class SpacegroupAnalyzer:
                     properties=site.properties,
                 )
                 if not any(map(new_s.is_periodic_image, new_sites)):
-                    new_sites.append(new_s)
+                    rhomb_sites.append(new_s)
             new_sites = rhomb_sites
 
         return Structure.from_sites(new_sites)

--- a/src/pymatgen/symmetry/analyzer.py
+++ b/src/pymatgen/symmetry/analyzer.py
@@ -531,30 +531,30 @@ class SpacegroupAnalyzer:
         if conv_lattice is None:
             conv = self.get_conventional_standard_structure(international_monoclinic=international_monoclinic)
             conv_lattice = conv.lattice
-        lattype = self.get_lattice_type()
 
-        if self.get_space_group_symbol().startswith("P"):
+        space_group = self.get_space_group_symbol()
+
+        if space_group.startswith("P"):
             return np.eye(3, dtype=np.float64)
 
-        if lattype == "rhombohedral":
-            # Check if the conventional representation is hexagonal or
-            # rhombohedral
-            if abs(conv_lattice.lengths[0] - conv_lattice.lengths[2]) < 1e-4:
-                return np.eye(3)
+        if space_group.startswith("R"):
             return np.array([[-1, 1, 1], [2, 1, 1], [-1, -2, 1]], dtype=np.float64) / 3
 
-        if self.get_space_group_symbol().startswith("I"):
+        if space_group.startswith("I"):
             return np.array([[-1, 1, 1], [1, -1, 1], [1, 1, -1]], dtype=np.float64) / 2
 
-        if self.get_space_group_symbol().startswith("F"):
+        if space_group.startswith("F"):
             return np.array([[0, 1, 1], [1, 0, 1], [1, 1, 0]], dtype=np.float64) / 2
 
-        if self.get_space_group_symbol().startswith(("C", "A")):
+        if space_group.startswith("C"):
             if self.get_crystal_system() == "monoclinic":
                 return np.array([[1, 1, 0], [-1, 1, 0], [0, 0, 2]], dtype=np.float64) / 2
             return np.array([[1, -1, 0], [1, 1, 0], [0, 0, 2]], dtype=np.float64) / 2
 
-        return np.eye(3, dtype=np.float64)
+        if space_group.startswith("A"):
+            return np.array([[2, 0, 0], [0, 1, 1], [0, -1, 1]], dtype=np.float64) / 2
+
+        raise ValueError(f"Unrecognized space group {space_group}.")
 
     @cite_conventional_cell_algo
     def get_primitive_standard_structure(

--- a/src/pymatgen/symmetry/analyzer.py
+++ b/src/pymatgen/symmetry/analyzer.py
@@ -511,7 +511,7 @@ class SpacegroupAnalyzer:
     @cite_conventional_cell_algo
     def get_conventional_to_primitive_transformation_matrix(
         self,
-        international_monoclinic: bool,
+        international_monoclinic: bool = True,
     ) -> NDArray:
         """Get the transformation matrix to transform a conventional unit cell to a
         primitive cell according to certain standards. The standards are defined in

--- a/src/pymatgen/symmetry/analyzer.py
+++ b/src/pymatgen/symmetry/analyzer.py
@@ -803,7 +803,7 @@ class SpacegroupAnalyzer:
                         a, b, c = lengths
                         alpha_degrees = angles[0]
 
-                    alpha_radians = math.pi * alpha_degrees / 180
+                    alpha_radians = math.radians(alpha_degrees)
                     new_matrix = [
                         [a, 0, 0],
                         [0, b, 0],
@@ -840,7 +840,7 @@ class SpacegroupAnalyzer:
                         transf[0][tp3[0]] = 1
                         transf[1][tp3[1]] = 1
 
-                    alpha = math.pi * alpha / 180
+                    alpha = math.radians(alpha)
                     new_matrix = [
                         [a, 0, 0],
                         [0, b, 0],
@@ -874,7 +874,7 @@ class SpacegroupAnalyzer:
             lattice = struct.lattice
 
             a, b, c = lattice.lengths
-            alpha, beta, gamma = (math.pi * i / 180 for i in lattice.angles)
+            alpha, beta, gamma = (math.radians(i) for i in lattice.angles)
             new_matrix = None
             test_matrix = [
                 [a, 0, 0],
@@ -953,7 +953,7 @@ class SpacegroupAnalyzer:
 
             lattice = Lattice(new_matrix)  # type:ignore[arg-type]
 
-        new_coords = np.dot(transf, np.transpose(struct.frac_coords)).T  # type: ignore[arg-type]
+        new_coords = struct.frac_coords @ transf.T  # type: ignore[arg-type]
         new_struct = Structure(
             lattice,
             struct.species_and_occu,

--- a/src/pymatgen/symmetry/analyzer.py
+++ b/src/pymatgen/symmetry/analyzer.py
@@ -514,7 +514,7 @@ class SpacegroupAnalyzer:
         international_monoclinic: bool = True,
     ) -> NDArray:
         """Get the transformation matrix to transform a conventional unit cell to a
-        primitive cell according to certain standards the standards are defined in
+        primitive cell according to certain standards. The standards are defined in
         Setyawan, W., & Curtarolo, S. (2010). High-throughput electronic band structure
         calculations: Challenges and tools. Computational Materials Science, 49(2),
         299-312. doi:10.1016/j.commatsci.2010.05.010.
@@ -527,12 +527,12 @@ class SpacegroupAnalyzer:
             Transformation matrix to go from conventional to primitive cell
         """
         conv = self.get_conventional_standard_structure(international_monoclinic=international_monoclinic)
-        lattice = self.get_lattice_type()
+        lattype = self.get_lattice_type()
 
-        if "P" in self.get_space_group_symbol() or lattice == "hexagonal":
+        if "P" in self.get_space_group_symbol() or lattype == "hexagonal":
             return np.eye(3)
 
-        if lattice == "rhombohedral":
+        if lattype == "rhombohedral":
             # Check if the conventional representation is hexagonal or
             # rhombohedral
             lengths = conv.lattice.lengths
@@ -633,7 +633,6 @@ class SpacegroupAnalyzer:
                 )
                 if not any(map(new_s.is_periodic_image, new_sites)):
                     new_sites.append(new_s)
-            return Structure.from_sites(new_sites)
 
         return Structure.from_sites(new_sites)
 

--- a/tests/symmetry/test_analyzer.py
+++ b/tests/symmetry/test_analyzer.py
@@ -502,6 +502,19 @@ class TestSpacegroupAnalyzer(MatSciTest):
         assert SpacegroupAnalyzer(primitive).get_space_group_number() == 166
         assert primitive.sites[0].species == spec
 
+    def test_primitivization_of_a_centered_cell(self):
+        """Test that an A-centered cell modifies alpha when primitivized."""
+        ortho_lattice = Lattice.orthorhombic(10, 11, 12)
+        species = ["Si", "Ge"]
+        # General sites
+        coords = [[0.137, 0.251, 0.389], [0.947, 0.370, 0.050]]
+        struct = Structure.from_spacegroup("Amm2", ortho_lattice, species, coords)
+        sga = SpacegroupAnalyzer(struct)
+
+        assert sga.get_space_group_number() == 38
+        # alpha is not 90° anymore
+        assert sga.get_primitive_standard_structure().lattice.alpha != 90
+
     def test_bad_structure(self):
         struct = Structure(Lattice.cubic(5), ["H", "H"], [[0.0, 0.0, 0.0], [0.001, 0.0, 0.0]])
 

--- a/tests/symmetry/test_analyzer.py
+++ b/tests/symmetry/test_analyzer.py
@@ -491,7 +491,6 @@ class TestSpacegroupAnalyzer(MatSciTest):
         # (but do not force a specific site ordering)
         assert primitive.sites[0].species in species
 
-        # Additionally, check that rhombohedral cells also use .species in primitivization
         # Initialize a rhombohedral cell with a hexagonal lattice
         spec = Composition({"H": 0.5})
         hex_rhomb = Structure.from_spacegroup(166, Lattice.hexagonal(5, 7), [spec], coords=np.zeros((1, 3)))
@@ -499,8 +498,14 @@ class TestSpacegroupAnalyzer(MatSciTest):
         # Primitive (rhombohedral) form should be 1/3, same spacegroup
         primitive = SpacegroupAnalyzer(hex_rhomb).get_primitive_standard_structure()
         assert len(primitive) == 1
-        assert SpacegroupAnalyzer(primitive).get_space_group_number() == 166
+        prim_sga = SpacegroupAnalyzer(primitive)
+        # Symmetry unchanged
+        assert prim_sga.get_space_group_number() == 166
+        # Check that rhombohedral cells also use .species in primitivization
         assert primitive.sites[0].species == spec
+        # Re-standardizaion leads back to 3 sites
+        re_standard = prim_sga.get_conventional_standard_structure()
+        assert len(re_standard) == 3
 
     def test_primitivization_of_a_centered_cell(self):
         """Test that an A-centered cell modifies gamma when primitivized."""
@@ -516,7 +521,12 @@ class TestSpacegroupAnalyzer(MatSciTest):
         # (Note that this happens because the A-centering is changed to C-centering
         # during standardization [without changing the saved space group!]. For normal
         # A-centering it would be alpha != 90.)
-        assert sga.get_primitive_standard_structure().lattice.gamma != 90
+        lattice = sga.get_primitive_standard_structure().lattice
+        assert lattice.gamma != 90
+        # Due to the same standardization, the previous a parameter is unchanged in c
+        assert math.isclose(lattice.c, 10)
+        # and a/b are approximately equal
+        assert math.isclose(lattice.a, lattice.b)
 
     def test_bad_structure(self):
         struct = Structure(Lattice.cubic(5), ["H", "H"], [[0.0, 0.0, 0.0], [0.001, 0.0, 0.0]])

--- a/tests/symmetry/test_analyzer.py
+++ b/tests/symmetry/test_analyzer.py
@@ -10,6 +10,7 @@ from pytest import approx
 from spglib import SpglibDataset
 
 from pymatgen.core import Lattice, Molecule, PeriodicSite, Site, Species, Structure
+from pymatgen.core.composition import Composition
 from pymatgen.io.vasp.outputs import Vasprun
 from pymatgen.symmetry.analyzer import (
     PointGroupAnalyzer,
@@ -465,13 +466,14 @@ class TestSpacegroupAnalyzer(MatSciTest):
 
     def test_hexagonal_almost_rhombohedral(self):
         """Test that #4679 is fixed (hexagonal lattice with a close to c is not rhombohedral)."""
+        species = [Composition({"Gd": 0.5}), Composition({"Se": 0.5}), Composition({"F": 0.5})]
         structure = Structure(
             lattice=[
                 [4.0570938, 0.0, 0.0],
                 [0.0, 4.0572993, 0.0],
                 [0.0, -2.02864965, 3.51372426],
             ],
-            species=["Gd", "Se", "F"],
+            species=species,
             coords=[
                 [0.67496701, 2.02864967, 1.17124141],
                 [2.70478423, -2.02864966e-8, 2.34248285],
@@ -481,8 +483,13 @@ class TestSpacegroupAnalyzer(MatSciTest):
         )
 
         sga = SpacegroupAnalyzer(structure, symprec=0.01)
+        primitive = sga.get_primitive_standard_structure()
         # 3 atoms expected in primitive rhombohedral cell (not 9)
-        assert len(sga.get_primitive_standard_structure()) == 3
+        assert len(primitive) == 3
+
+        # Check that sites are still half-occupied
+        # (but do not force a specific site ordering)
+        assert primitive.sites[0].species in species
 
     def test_bad_structure(self):
         struct = Structure(Lattice.cubic(5), ["H", "H"], [[0.0, 0.0, 0.0], [0.001, 0.0, 0.0]])

--- a/tests/symmetry/test_analyzer.py
+++ b/tests/symmetry/test_analyzer.py
@@ -463,6 +463,27 @@ class TestSpacegroupAnalyzer(MatSciTest):
         assert spg_analyzer.get_crystal_system() == "tetragonal"
         assert spg_analyzer.get_hall() == "-I 4 2"
 
+    def test_hexagonal_almost_rhombohedral(self):
+        """Test that #4679 is fixed (hexagonal lattice with a close to c is not rhombohedral)."""
+        structure = Structure(
+            lattice=[
+                [4.0570938, 0.0, 0.0],
+                [0.0, 4.0572993, 0.0],
+                [0.0, -2.02864965, 3.51372426],
+            ],
+            species=["Gd", "Se", "F"],
+            coords=[
+                [0.67496701, 2.02864967, 1.17124141],
+                [2.70478423, -2.02864966e-8, 2.34248285],
+                [0.67734256, 0.0, 0.0],
+            ],
+            coords_are_cartesian=True,
+        )
+
+        sga = SpacegroupAnalyzer(structure, symprec=0.01)
+        # 3 atoms expected in primitive rhombohedral cell (not 9)
+        assert len(sga.get_primitive_standard_structure()) == 3
+
     def test_bad_structure(self):
         struct = Structure(Lattice.cubic(5), ["H", "H"], [[0.0, 0.0, 0.0], [0.001, 0.0, 0.0]])
 

--- a/tests/symmetry/test_analyzer.py
+++ b/tests/symmetry/test_analyzer.py
@@ -491,6 +491,17 @@ class TestSpacegroupAnalyzer(MatSciTest):
         # (but do not force a specific site ordering)
         assert primitive.sites[0].species in species
 
+        # Additionally, check that rhombohedral cells also use .species in primitivization
+        # Initialize a rhombohedral cell with a hexagonal lattice
+        spec = Composition({"H": 0.5})
+        hex_rhomb = Structure.from_spacegroup(166, Lattice.hexagonal(5, 7), [spec], coords=np.zeros((1, 3)))
+        assert len(hex_rhomb) == 3
+        # Primitive (rhombohedral) form should be 1/3, same spacegroup
+        primitive = SpacegroupAnalyzer(hex_rhomb).get_primitive_standard_structure()
+        assert len(primitive) == 1
+        assert SpacegroupAnalyzer(primitive).get_space_group_number() == 166
+        assert primitive.sites[0].species == spec
+
     def test_bad_structure(self):
         struct = Structure(Lattice.cubic(5), ["H", "H"], [[0.0, 0.0, 0.0], [0.001, 0.0, 0.0]])
 

--- a/tests/symmetry/test_analyzer.py
+++ b/tests/symmetry/test_analyzer.py
@@ -503,7 +503,7 @@ class TestSpacegroupAnalyzer(MatSciTest):
         assert primitive.sites[0].species == spec
 
     def test_primitivization_of_a_centered_cell(self):
-        """Test that an A-centered cell modifies alpha when primitivized."""
+        """Test that an A-centered cell modifies gamma when primitivized."""
         ortho_lattice = Lattice.orthorhombic(10, 11, 12)
         species = ["Si", "Ge"]
         # General sites
@@ -512,8 +512,11 @@ class TestSpacegroupAnalyzer(MatSciTest):
         sga = SpacegroupAnalyzer(struct)
 
         assert sga.get_space_group_number() == 38
-        # alpha is not 90° anymore
-        assert sga.get_primitive_standard_structure().lattice.alpha != 90
+        # *gamma* is not 90° anymore
+        # (Note that this happens because the A-centering is changed to C-centering
+        # during standardization [without changing the saved space group!]. For normal
+        # A-centering it would be alpha != 90.)
+        assert sga.get_primitive_standard_structure().lattice.gamma != 90
 
     def test_bad_structure(self):
         struct = Structure(Lattice.cubic(5), ["H", "H"], [[0.0, 0.0, 0.0], [0.001, 0.0, 0.0]])


### PR DESCRIPTION
Fixes a variety of small issues with the SpacegroupAnalyzer, in particular with `get_primitive_standard_structure` and similar functions:
1. `get_primitive_standard_structure` now actually checks for the rhombohedral lattice type (instead of checking if the lattice is equal to the string "rhombohedral"). The unused code was changed to use .species instead of .specie so disordered structures work.
2. `get_primitive_standard_structure` now only creates the standard structure once, instead of twice (one extra time via `get_conventional_to_primitive_transformation_matrix`).
3. Centering checks of the space group now only check the first letter, as that is the only relevant letter.
4. All hexagonal space groups start with P, so checking the lattice type was duplicated.
5. `get_primitive_standard_structure` now always returns a float64-typed matrix.
6. Fixes materialsproject/pymatgen#4679 by adding an angle check to `get_conventional_standard_structure`.
7. Removes the list(range) in `itertools.permutations`, as that is unnecessary.
8. Fixes some Docstring typos and indentation mistakes (checked against VS Code tooltips).

## Checklist

- [x] Google format doc strings added. Check with `ruff`.
- [x] Type annotations included. Check with `mypy`.
- [x] Tests added for new features/fixes.

