### PR TITLE
Use full-precision 2 pi constant

### DIFF
--- a/src/pymatgen/io/vasp/outputs.py
+++ b/src/pymatgen/io/vasp/outputs.py
@@ -692,7 +692,7 @@ class Vasprun(MSONable):
                 the unit is cm^-1.
                 """
                 hc = _const.h * _const.c / _const.e * 100  # eV*cm (J*m -> eV*cm)
-                return 2 * 3.14159 * np.sqrt(np.sqrt(real**2 + imag**2) - real) * np.sqrt(2) / hc * freq
+                return math.tau * math.sqrt(math.sqrt(real**2 + imag**2) - real) * math.sqrt(2) / hc * freq
 
             return list(
                 itertools.starmap(


### PR DESCRIPTION
Fixes #89 by using `math.tau` for 2 pi.
Also changes np. functions to math. as floats are used (slightly faster and easier to understand).
Arguably `real**2`/`imag**2` should be `real * real`/`imag * imag`, but that is a rather minimal improvement.
