### PR TITLE
Handle uncommon coordinate shapes

### DIFF
--- a/src/pymatgen/core/lattice.py
+++ b/src/pymatgen/core/lattice.py
@@ -1619,8 +1619,10 @@ class Lattice(MSONable):
             2d array of Cartesian distances. E.g the distance between
             frac_coords1[i] and frac_coords2[j] is distances[i,j]
         """
-        _v, d2 = pbc_shortest_vectors(self, frac_coords1, frac_coords2, return_d2=True)
-        return np.sqrt(d2)
+        if len(frac_coords1) and len(frac_coords2):
+            _v, d2 = pbc_shortest_vectors(self, frac_coords1, frac_coords2, return_d2=True)
+            return np.sqrt(d2)
+        return np.empty((len(frac_coords1), len(frac_coords2)), dtype=np.float64)
 
     def is_hexagonal(
         self,

--- a/src/pymatgen/core/lattice.py
+++ b/src/pymatgen/core/lattice.py
@@ -215,7 +215,7 @@ class Lattice(MSONable):
         """Get the Cartesian coordinates given fractional coordinates.
 
         Args:
-            fractional_coords (3x1 array): Fractional coords.
+            fractional_coords (3x1 or Nx3 array): Fractional coords.
 
         Returns:
             Cartesian coordinates
@@ -226,7 +226,7 @@ class Lattice(MSONable):
         """Get the fractional coordinates given Cartesian coordinates.
 
         Args:
-            cart_coords (3x1 array): Cartesian coords.
+            cart_coords (3x1 or Nx3 array): Cartesian coords.
 
         Returns:
             Fractional coordinates.
@@ -248,7 +248,7 @@ class Lattice(MSONable):
         class in `pymatgen.analysis.ferroelectricity.polarization`.
 
         Args:
-            cart_coords (3x1 array): Cartesian coords.
+            cart_coords (3x1 or Nx3 array): Cartesian coords.
 
         Returns:
             Lattice coordinates.

--- a/src/pymatgen/core/sites.py
+++ b/src/pymatgen/core/sites.py
@@ -416,7 +416,7 @@ class PeriodicSite(Site, MSONable):
 
     @lattice.setter
     def lattice(self, lattice: Lattice) -> None:
-        """Set Lattice associated with PeriodicSite."""
+        """Set Lattice associated with PeriodicSite. The old fractional coordinates remain."""
         self._lattice = lattice
         self._coords = self._lattice.get_cartesian_coords(self._frac_coords)
 
@@ -431,6 +431,8 @@ class PeriodicSite(Site, MSONable):
     def coords(self, coords: ArrayLike) -> None:
         """Set Cartesian coordinates."""
         self._coords = np.asarray(coords, dtype=np.float64)
+        if self._coords.shape != (3,):
+            raise ValueError(f"Cartesian coordinates {self._coords} are invalid - expected shape is (3,).")
         self._frac_coords = self._lattice.get_fractional_coords(self._coords)
 
     @property
@@ -442,6 +444,8 @@ class PeriodicSite(Site, MSONable):
     def frac_coords(self, frac_coords: ArrayLike) -> None:
         """Set fractional coordinates."""
         self._frac_coords = np.array(frac_coords, dtype=np.float64)
+        if self._frac_coords.shape != (3,):
+            raise ValueError(f"Fractional coordinates {self._frac_coords} are invalid - expected shape is (3,).")
         self._coords = self._lattice.get_cartesian_coords(self._frac_coords)
 
     @property

--- a/src/pymatgen/core/sites.py
+++ b/src/pymatgen/core/sites.py
@@ -357,8 +357,13 @@ class PeriodicSite(Site, MSONable):
         if to_unit_cell:
             frac_coords = np.array([np.mod(f, 1) if p else f for p, f in zip(lattice.pbc, frac_coords, strict=True)])  # type: ignore[arg-type]
 
+        frac_coords = np.asarray(frac_coords, dtype=np.float64)
+
         if not skip_checks:
-            frac_coords = np.array(frac_coords)
+            if frac_coords.shape != (3,):
+                raise ValueError(
+                    f"Coordinates {frac_coords} for species {species} are not xyz-shaped (shape {frac_coords.shape})."
+                )
             if not isinstance(species, Composition):
                 try:
                     species = Composition({get_el_sp(species): 1})  # type: ignore[arg-type]
@@ -370,7 +375,7 @@ class PeriodicSite(Site, MSONable):
                 raise ValueError("Species occupancies sum to more than 1!")
 
         self._lattice: Lattice = lattice
-        self._frac_coords: NDArray[np.float64] = np.asarray(frac_coords, dtype=np.float64)
+        self._frac_coords: NDArray[np.float64] = frac_coords
         self._species: Composition = cast("Composition", species)
         self._coords: NDArray[np.float64] | None = None
         self.properties: dict = properties or {}

--- a/src/pymatgen/core/sites.py
+++ b/src/pymatgen/core/sites.py
@@ -355,7 +355,9 @@ class PeriodicSite(Site, MSONable):
         frac_coords = lattice.get_fractional_coords(coords) if coords_are_cartesian else coords
 
         if to_unit_cell:
-            frac_coords = np.array([np.mod(f, 1) if p else f for p, f in zip(lattice.pbc, frac_coords, strict=True)])  # type: ignore[arg-type]
+            frac_coords = np.array(
+                [np.mod(f, 1) if p else f for p, f in zip(lattice.pbc, frac_coords, strict=True)], dtype=np.float64
+            )
 
         frac_coords = np.asarray(frac_coords, dtype=np.float64)
 

--- a/src/pymatgen/core/structure.py
+++ b/src/pymatgen/core/structure.py
@@ -1080,7 +1080,7 @@ class IStructure(SiteCollection, MSONable):
 
         self._lattice = lattice if isinstance(lattice, Lattice) else Lattice(lattice)
 
-        sites = []
+        sites: list[PeriodicSite] = []
         for idx, specie in enumerate(species):
             prop = None
             if site_properties:

--- a/src/pymatgen/core/structure.py
+++ b/src/pymatgen/core/structure.py
@@ -408,7 +408,9 @@ class SiteCollection(collections.abc.Sequence, ABC):
     @property
     def cart_coords(self) -> NDArray[np.float64]:
         """An np.array of the Cartesian coordinates of sites in the structure."""
-        return np.array([site.coords for site in self])
+        if len(self):
+            return np.array([site.coords for site in self])
+        return np.empty((0, 3), dtype=np.float64)
 
     @property
     def formula(self) -> str:
@@ -1623,7 +1625,9 @@ class IStructure(SiteCollection, MSONable):
     @property
     def frac_coords(self):
         """Fractional coordinates as a Nx3 numpy array."""
-        return np.array([site.frac_coords for site in self])
+        if len(self):
+            return np.array([site.frac_coords for site in self])
+        return np.empty((0, 3), dtype=np.float64)
 
     @property
     def volume(self) -> float:

--- a/tests/core/test_lattice.py
+++ b/tests/core/test_lattice.py
@@ -487,6 +487,16 @@ class TestLattice(MatSciTest):
         output3 = lattice_pbc.get_all_distances(frac_coords[:-1], frac_coords)
         assert_allclose(output3, expected_pbc, 3)
 
+        # Test that an empty array does not crash the function
+        frac_coords_2 = np.empty((0, 3), dtype=np.float64)
+
+        dists = lattice.get_all_distances(frac_coords, frac_coords_2)
+        # Shape should preserve coordinate counts
+        assert dists.shape == (5, 0)
+        # Same match, the other way around
+        dists = lattice.get_all_distances(frac_coords_2, frac_coords)
+        assert dists.shape == (0, 5)
+
     def test_monoclinic(self):
         assert self.monoclinic.angles == approx([90, 66, 90])
         assert self.monoclinic.lengths == approx([10, 20, 30])

--- a/tests/core/test_sites.py
+++ b/tests/core/test_sites.py
@@ -279,6 +279,19 @@ class TestPeriodicSite(MatSciTest):
         assert str(self.propertied_site) == "[2.5 3.5 4.5] Fe2+"
         assert str(self.labeled_site) == "[2.5 3.5 4.5] Fe"
 
+    def test_invalid_coordinate(self):
+        """Test that non (3,)-shaped coordinate settings are blocked."""
+        with pytest.raises(ValueError, match="Coordinates"):
+            PeriodicSite("H", np.zeros((2,)), Lattice.cubic(1))
+
+        # Also block the setters from accepting false shapes
+        okay = PeriodicSite("H", np.zeros((3,)), Lattice.cubic(1))
+        with pytest.raises(ValueError, match="coordinates"):
+            okay.frac_coords = np.zeros((2,))
+        okay = PeriodicSite("H", np.zeros((3,)), Lattice.cubic(1))
+        with pytest.raises(ValueError, match="coordinates"):
+            okay.coords = np.zeros((2,))
+
 
 def get_distance_and_image_old(site1, site2, jimage=None):
     """

--- a/tests/core/test_structure.py
+++ b/tests/core/test_structure.py
@@ -1035,6 +1035,12 @@ Direct
         with pytest.raises(ValueError, match="Invalid backend='42'"):
             self.struct.get_symmetry_dataset(backend="42")
 
+    def test_siteless_structure(self):
+        """Test that a Structure without sites returns 2D coordinates."""
+        empty = IStructure(Lattice.cubic(1), [], np.empty((0, 3), dtype=np.float64))
+        assert empty.cart_coords.shape == (0, 3)
+        assert empty.frac_coords.shape == (0, 3)
+
 
 class TestStructure(MatSciTest):
     def setup_method(self):
@@ -2254,12 +2260,6 @@ Sites (8)
         struct_deuter.to(f"{self.tmp_path}/POSCAR_deuter")
         struct = Structure.from_file(f"{self.tmp_path}/POSCAR_deuter")
         assert "Deuterium" not in [el.long_name for el in struct.composition.elements]
-
-    def test_siteless_structure(self):
-        """Test that a Structure without sites returns 2D coordinates."""
-        empty = Structure(Lattice.cubic(1), [], np.empty((0, 3), dtype=np.float64))
-        assert empty.cart_coords.shape == (0, 3)
-        assert empty.frac_coords.shape == (0, 3)
 
 
 class TestIMolecule(MatSciTest):

--- a/tests/core/test_structure.py
+++ b/tests/core/test_structure.py
@@ -2255,6 +2255,12 @@ Sites (8)
         struct = Structure.from_file(f"{self.tmp_path}/POSCAR_deuter")
         assert "Deuterium" not in [el.long_name for el in struct.composition.elements]
 
+    def test_siteless_structure(self):
+        """Test that a Structure without sites returns 2D coordinates."""
+        empty = Structure(Lattice.cubic(1), [], np.empty((0, 3), dtype=np.float64))
+        assert empty.cart_coords.shape == (0, 3)
+        assert empty.frac_coords.shape == (0, 3)
+
 
 class TestIMolecule(MatSciTest):
     def setup_method(self):

--- a/tests/core/test_structure.py
+++ b/tests/core/test_structure.py
@@ -1041,6 +1041,13 @@ Direct
         assert empty.cart_coords.shape == (0, 3)
         assert empty.frac_coords.shape == (0, 3)
 
+    def test_broken_coordinates(self):
+        """Test that broken coordinates cause an explicit error."""
+        # Second coordinate is only 2D
+        coords = [[0, 0, 0], [0.5, 0.5], [1, 1, 1]]
+        with pytest.raises(ValueError, match="Coordinates"):
+            IStructure(Lattice.cubic(1), ["H", "H", "H"], coords)
+
 
 class TestStructure(MatSciTest):
     def setup_method(self):


### PR DESCRIPTION
Hardens the shape of `.coords`/`.frac_coords`/`.cart_coords` and derivatives:
1. `IStructure.frac_coords` and `IStructure.cart_coords` are now always (N, 3) shaped (and therefore 2D), even if N is 0. This is relevant for some applications, e. g. unpacking or numba specialization.
2. `Lattice.get_all_distances` (used by `Structure.distance_matrix`) now doesn't crash for siteless structures, but instead produces an empty array of the correct 2D-shape.
3. PeriodicSites/IStructures are better protected from misshapen coordinates: On `PeriodicSite` creation and on `.coords`/`.frac_coords` setting, the shape is checked to be (3,). This protects users of those values from recieving arbitrary coordinate shapes (e. g. (2,), (1, 3), (999, 999, 999)...).
4. Docstrings for lattice-associated functions were clarified. The `get_x_coords`-functions are regularly used by pymatgen with (N, 3)-shaped inputs, but the docstrings did not show this option. PeriodicSites now note more clearly that the expectation from a lattice change is that the fractional coordinate is supposed to remain unchanged.
5. In `PeriodicSite`, the input coordinates are now only copied if they are a) cartesian, b) converted to the unit cell or c) not a float64-array. This is slightly different from before, as before they were always copied (potentially again) if `skip_checks == False` and potentially copied a second (or third) time if the np.mod does not return float64.

## Checklist

- [x] Google format doc strings added. Check with `ruff`.
- [x] Type annotations included. Check with `mypy`.
- [x] Tests added for new features/fixes.

