### PR TITLE
Use math.radians, math.degrees (or np.rad2deg, np.deg2rad for arrays) instead of calculating 180.0 / pi or pi / 180.0

### DIFF
--- a/src/pymatgen/core/interface.py
+++ b/src/pymatgen/core/interface.py
@@ -853,7 +853,7 @@ class GrainBoundaryGenerator:
 
         # For rhombohedral system, ratio = (1 + 2 * cos(alpha)) / cos(alpha)
         elif lat_type == "r":
-            cos_alpha = math.cos(structure.lattice.alpha / 180 * np.pi)
+            cos_alpha = math.cos(math.radians(structure.lattice.alpha))
             frac = Fraction((1 + 2 * cos_alpha) / cos_alpha).limit_denominator(max_denominator)
             ratio = [frac.numerator, frac.denominator]
 
@@ -1051,9 +1051,7 @@ class GrainBoundaryGenerator:
                 m = 0
                 n = 1
             else:
-                fraction = Fraction(
-                    np.tan(angle / 2 / 180.0 * np.pi) / np.sqrt(float(d) / 3.0 / mu)
-                ).limit_denominator()
+                fraction = Fraction(np.tan(math.radians(angle / 2)) / np.sqrt(float(d) / 3.0 / mu)).limit_denominator()
                 m = fraction.denominator
                 n = fraction.numerator
 
@@ -1110,7 +1108,7 @@ class GrainBoundaryGenerator:
                 m = 0
                 n = 1
             else:
-                fraction = Fraction(np.tan(angle / 2 / 180.0 * np.pi) / np.sqrt(float(d) / mu)).limit_denominator()
+                fraction = Fraction(np.tan(math.radians(angle / 2)) / np.sqrt(float(d) / mu)).limit_denominator()
                 m = fraction.denominator
                 n = fraction.numerator
 
@@ -1228,7 +1226,7 @@ class GrainBoundaryGenerator:
                 m = 0
                 n = 1
             else:
-                fraction = Fraction(np.tan(angle / 2 / 180.0 * np.pi) / np.sqrt(d / mu / lam)).limit_denominator()
+                fraction = Fraction(np.tan(math.radians(angle / 2)) / np.sqrt(d / mu / lam)).limit_denominator()
                 m = fraction.denominator
                 n = fraction.numerator
             r_list = [
@@ -1403,13 +1401,13 @@ class GrainBoundaryGenerator:
                             if m == 0:
                                 angle = 180.0
                             else:
-                                angle = 2 * np.arctan(n * np.sqrt(sum(np.array(r_axis) ** 2)) / m) / np.pi * 180
+                                angle = math.degrees(2 * np.arctan(n * np.sqrt(sum(np.array(r_axis) ** 2)) / m))
                             sigmas[sigma] = [angle]
                         else:
                             if m == 0:
                                 angle = 180.0
                             else:
-                                angle = 2 * np.arctan(n * np.sqrt(sum(np.array(r_axis) ** 2)) / m) / np.pi * 180
+                                angle = math.degrees(2 * np.arctan(n * np.sqrt(sum(np.array(r_axis) ** 2)) / m))
                             if angle not in sigmas[sigma]:
                                 sigmas[sigma].append(angle)
         return sigmas
@@ -1520,10 +1518,10 @@ class GrainBoundaryGenerator:
                     sigma = round((3 * mu * m**2 + d * n**2) / com_fac)
                     if 1 < sigma <= cutoff:
                         if sigma not in list(sigmas):
-                            angle = 180.0 if m == 0 else 2 * np.arctan(n / m * np.sqrt(d / 3.0 / mu)) / np.pi * 180
+                            angle = 180.0 if m == 0 else math.degrees(2 * np.arctan(n / m * np.sqrt(d / 3.0 / mu)))
                             sigmas[sigma] = [angle]
                         else:
-                            angle = 180.0 if m == 0 else 2 * np.arctan(n / m * np.sqrt(d / 3.0 / mu)) / np.pi * 180
+                            angle = 180.0 if m == 0 else math.degrees(2 * np.arctan(n / m * np.sqrt(d / 3.0 / mu)))
                             if angle not in sigmas[sigma]:
                                 sigmas[sigma].append(angle)
             if m_max == 0:
@@ -1649,10 +1647,10 @@ class GrainBoundaryGenerator:
                     sigma = round(abs(F / com_fac))
                     if 1 < sigma <= cutoff:
                         if sigma not in list(sigmas):
-                            angle = 180.0 if m == 0 else 2 * np.arctan(n / m * np.sqrt(d / mu)) / np.pi * 180
+                            angle = 180.0 if m == 0 else math.degrees(2 * np.arctan(n / m * np.sqrt(d / mu)))
                             sigmas[sigma] = [angle]
                         else:
-                            angle = 180 if m == 0 else 2 * np.arctan(n / m * np.sqrt(d / mu)) / np.pi * 180.0
+                            angle = 180 if m == 0 else math.degrees(2 * np.arctan(n / m * np.sqrt(d / mu)))
                             if angle not in sigmas[sigma]:
                                 sigmas[sigma].append(angle)
             if m_max == 0:
@@ -1750,10 +1748,10 @@ class GrainBoundaryGenerator:
                     sigma = round((mu * m**2 + d * n**2) / com_fac)
                     if 1 < sigma <= cutoff:
                         if sigma not in list(sigmas):
-                            angle = 180.0 if m == 0 else 2 * np.arctan(n / m * np.sqrt(d / mu)) / np.pi * 180
+                            angle = 180.0 if m == 0 else math.degrees(2 * np.arctan(n / m * np.sqrt(d / mu)))
                             sigmas[sigma] = [angle]
                         else:
-                            angle = 180.0 if m == 0 else 2 * np.arctan(n / m * np.sqrt(d / mu)) / np.pi * 180
+                            angle = 180.0 if m == 0 else math.degrees(2 * np.arctan(n / m * np.sqrt(d / mu)))
                             if angle not in sigmas[sigma]:
                                 sigmas[sigma].append(angle)
             if m_max == 0:
@@ -1888,10 +1886,10 @@ class GrainBoundaryGenerator:
                     sigma = round((mu * lam * m**2 + d * n**2) / com_fac)
                     if 1 < sigma <= cutoff:
                         if sigma not in list(sigmas):
-                            angle = 180.0 if m == 0 else 2 * np.arctan(n / m * np.sqrt(d / mu / lam)) / np.pi * 180
+                            angle = 180.0 if m == 0 else math.degrees(2 * np.arctan(n / m * np.sqrt(d / mu / lam)))
                             sigmas[sigma] = [angle]
                         else:
-                            angle = 180.0 if m == 0 else 2 * np.arctan(n / m * np.sqrt(d / mu / lam)) / np.pi * 180
+                            angle = 180.0 if m == 0 else math.degrees(2 * np.arctan(n / m * np.sqrt(d / mu / lam)))
                             if angle not in sigmas[sigma]:
                                 sigmas[sigma].append(angle)
             if m_max == 0:

--- a/src/pymatgen/core/lattice.py
+++ b/src/pymatgen/core/lattice.py
@@ -175,7 +175,7 @@ class Lattice(MSONable):
             jj = (dim + 1) % 3
             kk = (dim + 2) % 3
             angles[dim] = np.clip(np.dot(matrix[jj], matrix[kk]) / (lengths[jj] * lengths[kk]), -1, 1)
-        angles = np.arccos(angles) * 180.0 / np.pi  # type: ignore[assignment]
+        angles = np.rad2deg(np.arccos(angles))  # type: ignore[assignment]
         return tuple(angles.tolist())  # type: ignore[return-value]
 
     @cached_property
@@ -957,7 +957,7 @@ class Lattice(MSONable):
             x = np.inner(v1, v2) / l1[:, None] / l2
             x[x > 1] = 1
             x[x < -1] = -1
-            return np.arccos(x) * 180.0 / np.pi
+            return math.degrees(np.arccos(x))
 
         lengths = other_lattice.lengths
         alpha, beta, gamma = other_lattice.angles
@@ -1261,9 +1261,9 @@ class Lattice(MSONable):
         a = math.sqrt(A)
         b = math.sqrt(B)
         c = math.sqrt(C)
-        alpha = math.acos(E / 2 / b / c) / math.pi * 180
-        beta = math.acos(N / 2 / a / c) / math.pi * 180
-        gamma = math.acos(Y / 2 / a / b) / math.pi * 180
+        alpha = math.degrees(math.acos(E / 2 / b / c))
+        beta = math.degrees(math.acos(N / 2 / a / c))
+        gamma = math.degrees(math.acos(Y / 2 / a / b))
         lattice = type(self).from_parameters(a, b, c, alpha, beta, gamma)
 
         mapped = self.find_mapping(lattice, e, skip_rotation_matrix=True)

--- a/src/pymatgen/core/lattice.py
+++ b/src/pymatgen/core/lattice.py
@@ -957,7 +957,7 @@ class Lattice(MSONable):
             x = np.inner(v1, v2) / l1[:, None] / l2
             x[x > 1] = 1
             x[x < -1] = -1
-            return math.degrees(np.arccos(x))
+            return np.rad2deg(np.arccos(x))
 
         lengths = other_lattice.lengths
         alpha, beta, gamma = other_lattice.angles

--- a/src/pymatgen/core/operations.py
+++ b/src/pymatgen/core/operations.py
@@ -286,7 +286,7 @@ class SymmOp(MSONable):
 
         vec = np.asarray(translation_vec)
 
-        ang = angle if angle_in_radians else angle * np.pi / 180
+        ang = angle if angle_in_radians else math.radians(angle)
         cos_a = math.cos(ang)
         sin_a = math.sin(ang)
         unit_vec: NDArray = axis / np.linalg.norm(axis)  # type:ignore[call-overload]
@@ -324,7 +324,7 @@ class SymmOp(MSONable):
         Returns:
             SymmOp.
         """
-        theta: float = angle if angle_in_radians else angle * np.pi / 180
+        theta: float = angle if angle_in_radians else math.radians(angle)
         a: float
         b: float
         c: float


### PR DESCRIPTION
Changes all instances (that I could find) of manual radians <-> degrees conversion to the math function (or the numpy function, if needed).