### PR TITLE
[Breaking] Deprecate `Orbital.dx2` with `Orbital.dx2_y2`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,22 @@ uv run invoke lint             # ruff + mypy + ruff format
 uv run invoke update-changelog # generate CHANGES.md from PRs (uses OPENAPI_KEY for GPT summarization)
 ```
 
+## Machine-generated files — do not edit by hand
+
+The following files are regenerated at release time by `invoke update-changelog` (see
+`tasks.py`) and must **not** be edited manually — hand-edits are overwritten or duplicated
+by the next release run:
+
+- `CHANGES.md` — release changelog, GPT-summarized from merged PR titles/bodies.
+- `COMPATIBILITY.md` — breaking-change log, assembled from PRs whose title starts with
+  `[breaking]` by copying their `## Breaking Changes` body section verbatim.
+
+To influence their content, edit the PR instead: for `COMPATIBILITY.md`, prefix the PR
+title with `[breaking]` and describe the change (plus migration steps) under
+`## Breaking Changes` in the PR body; describe the change in the PR body to steer the
+`CHANGES.md` summary. The package version is likewise derived from the exact `vYYYY.M.D`
+Git tag, not from any file (see Versioning & release).
+
 ## Cython extensions — important
 
 `setup.py` builds two Cython extensions:

--- a/src/pymatgen/electronic_structure/bandstructure.py
+++ b/src/pymatgen/electronic_structure/bandstructure.py
@@ -676,6 +676,7 @@ class BandStructure:
         labels_dict = {k.strip(): v for k, v in dct["labels_dict"].items()}
         projections: dict = {}
         structure = None
+        warned_legacy_dx2 = False
         if dct.get("projections"):
             structure = Structure.from_dict(dct["structure"])
             projections = {}
@@ -687,10 +688,18 @@ class BandStructure:
                         dddd = []
                         for kk in range(len(dct["projections"][spin][ii][jj])):
                             orb = Orbital(kk).name
-                            ddddd = [
-                                dct["projections"][spin][ii][jj][orb][ll]
-                                for ll in range(len(dct["projections"][spin][ii][jj][orb]))
-                            ]
+                            projection = dct["projections"][spin][ii][jj]
+                            if orb == "dx2_y2" and "dx2_y2" not in projection and "dx2" in projection:
+                                if not warned_legacy_dx2:
+                                    warnings.warn(
+                                        "The 'dx2' orbital name in serialized band structures is deprecated; "
+                                        "use 'dx2_y2' instead.",
+                                        DeprecationWarning,
+                                        stacklevel=2,
+                                    )
+                                    warned_legacy_dx2 = True
+                                orb = "dx2"
+                            ddddd = [projection[orb][ll] for ll in range(len(projection[orb]))]
 
                             dddd.append(np.array(ddddd))
                         ddd.append(np.array(dddd))

--- a/src/pymatgen/electronic_structure/bandstructure.py
+++ b/src/pymatgen/electronic_structure/bandstructure.py
@@ -693,7 +693,7 @@ class BandStructure:
                                 if not warned_legacy_dx2:
                                     warnings.warn(
                                         "The 'dx2' orbital name in serialized band structures is deprecated; "
-                                        "use 'dx2_y2' instead.",
+                                        "use 'dx2_y2' instead. It will be removed on 2027-08-17.",
                                         DeprecationWarning,
                                         stacklevel=2,
                                     )

--- a/src/pymatgen/electronic_structure/cohp.py
+++ b/src/pymatgen/electronic_structure/cohp.py
@@ -345,18 +345,7 @@ class CompleteCohp(Cohp):
             }
 
         if self.orb_res_cohp:
-            # TODO(2027-08-17): Serialize canonical "dx2_y2" names and remove this compatibility warning.
-            if any(
-                "dx2_y2" in orbs or any(orbital is Orbital.dx2_y2 for _, orbital in cohp["orbitals"])
-                for orbital_cohps in self.orb_res_cohp.values()
-                for orbs, cohp in orbital_cohps.items()
-            ):
-                warnings.warn(
-                    "CompleteCohp.as_dict() temporarily serializes 'dx2_y2' as 'dx2' for backward compatibility. "
-                    "It will serialize 'dx2_y2' on or after 2027-08-17.",
-                    DeprecationWarning,
-                    stacklevel=2,
-                )
+            # TODO(2027-08-17): Serialize canonical "dx2_y2" names instead of the legacy "dx2" spelling.
             orb_dict: dict[str, Any] = {}
             for label in self.orb_res_cohp:
                 orb_dict[label] = {}

--- a/src/pymatgen/electronic_structure/cohp.py
+++ b/src/pymatgen/electronic_structure/cohp.py
@@ -658,6 +658,7 @@ class CompleteCohp(Cohp):
 
         if "orb_res_cohp" in dct:
             orb_cohp: dict[str, dict[Orbital, dict[str, Any]]] = {}
+            warned_legacy_dx2 = False
             for label in dct["orb_res_cohp"]:
                 orb_cohp[label] = {}
                 for orb in dct["orb_res_cohp"][label]:
@@ -672,8 +673,22 @@ class CompleteCohp(Cohp):
                         }
                     except KeyError:
                         icohp = None
-                    orbitals = [(int(o[0]), Orbital[o[1]]) for o in dct["orb_res_cohp"][label][orb]["orbitals"]]
-                    orb_cohp[label][orb] = {
+                    orbitals = []
+                    for orbital in dct["orb_res_cohp"][label][orb]["orbitals"]:
+                        orbital_name = orbital[1]
+                        if orbital_name == "dx2":
+                            if not warned_legacy_dx2:
+                                warnings.warn(
+                                    "The 'dx2' orbital name in serialized COHP data is deprecated; "
+                                    "use 'dx2_y2' instead.",
+                                    DeprecationWarning,
+                                    stacklevel=2,
+                                )
+                                warned_legacy_dx2 = True
+                            orbital_name = "dx2_y2"
+                        orbitals.append((int(orbital[0]), Orbital[orbital_name]))
+                    canonical_orb = orb if "dx2_y2" in orb else orb.replace("dx2", "dx2_y2")
+                    orb_cohp[label][canonical_orb] = {
                         "COHP": cohp,
                         "ICOHP": icohp,
                         "orbitals": orbitals,

--- a/src/pymatgen/electronic_structure/cohp.py
+++ b/src/pymatgen/electronic_structure/cohp.py
@@ -345,18 +345,33 @@ class CompleteCohp(Cohp):
             }
 
         if self.orb_res_cohp:
+            # TODO(2027-08-17): Serialize canonical "dx2_y2" names and remove this compatibility warning.
+            if any(
+                "dx2_y2" in orbs or any(orbital is Orbital.dx2_y2 for _, orbital in cohp["orbitals"])
+                for orbital_cohps in self.orb_res_cohp.values()
+                for orbs, cohp in orbital_cohps.items()
+            ):
+                warnings.warn(
+                    "CompleteCohp.as_dict() temporarily serializes 'dx2_y2' as 'dx2' for backward compatibility. "
+                    "It will serialize 'dx2_y2' on or after 2027-08-17.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
             orb_dict: dict[str, Any] = {}
             for label in self.orb_res_cohp:
                 orb_dict[label] = {}
                 for orbs in self.orb_res_cohp[label]:
-                    orb_dict[label][orbs] = {
+                    orb_dict[label][orbs.replace("dx2_y2", "dx2")] = {
                         "COHP": {
                             str(spin): pops.tolist() for spin, pops in self.orb_res_cohp[label][orbs]["COHP"].items()
                         },
                         "ICOHP": {
                             str(spin): pops.tolist() for spin, pops in self.orb_res_cohp[label][orbs]["ICOHP"].items()
                         },
-                        "orbitals": [[orb[0], orb[1].name] for orb in self.orb_res_cohp[label][orbs]["orbitals"]],
+                        "orbitals": [
+                            [principal_qn, "dx2" if orbital is Orbital.dx2_y2 else orbital.name]
+                            for principal_qn, orbital in self.orb_res_cohp[label][orbs]["orbitals"]
+                        ],
                     }
 
             dct["orb_res_cohp"] = orb_dict
@@ -658,7 +673,6 @@ class CompleteCohp(Cohp):
 
         if "orb_res_cohp" in dct:
             orb_cohp: dict[str, dict[Orbital, dict[str, Any]]] = {}
-            warned_legacy_dx2 = False
             for label in dct["orb_res_cohp"]:
                 orb_cohp[label] = {}
                 for orb in dct["orb_res_cohp"][label]:
@@ -673,21 +687,12 @@ class CompleteCohp(Cohp):
                         }
                     except KeyError:
                         icohp = None
+                    # TODO(2027-08-17): Remove legacy "dx2" deserialization.
                     orbitals = []
                     for orbital in dct["orb_res_cohp"][label][orb]["orbitals"]:
-                        orbital_name = orbital[1]
-                        if orbital_name == "dx2":
-                            if not warned_legacy_dx2:
-                                warnings.warn(
-                                    "The 'dx2' orbital name in serialized COHP data is deprecated; "
-                                    "use 'dx2_y2' instead.",
-                                    DeprecationWarning,
-                                    stacklevel=2,
-                                )
-                                warned_legacy_dx2 = True
-                            orbital_name = "dx2_y2"
+                        orbital_name = "dx2_y2" if orbital[1] == "dx2" else orbital[1]
                         orbitals.append((int(orbital[0]), Orbital[orbital_name]))
-                    canonical_orb = orb if "dx2_y2" in orb else orb.replace("dx2", "dx2_y2")
+                    canonical_orb = re.sub(r"dx2(?!_y2)", "dx2_y2", orb)
                     orb_cohp[label][canonical_orb] = {
                         "COHP": cohp,
                         "ICOHP": icohp,

--- a/src/pymatgen/electronic_structure/core.py
+++ b/src/pymatgen/electronic_structure/core.py
@@ -4,7 +4,8 @@ including Spin, Orbital and Magmom.
 
 from __future__ import annotations
 
-from enum import Enum, unique
+import warnings
+from enum import Enum, EnumMeta, unique
 from typing import TYPE_CHECKING, Literal, cast
 
 import numpy as np
@@ -49,8 +50,32 @@ class OrbitalType(Enum):
         return cast("Literal['s', 'p', 'd', 'f']", str(self.name))
 
 
+class _OrbitalMeta(EnumMeta):
+    """Metaclass providing deprecated orbital-name compatibility."""
+
+    def __getattribute__(cls, name: str):
+        if name == "dx2":
+            warnings.warn(
+                "Orbital.dx2 is deprecated; use Orbital.dx2_y2 instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            name = "dx2_y2"
+        return super().__getattribute__(name)
+
+    def __getitem__(cls, name: str):
+        if name == "dx2":
+            warnings.warn(
+                "The 'dx2' orbital name is deprecated; use 'dx2_y2' instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            name = "dx2_y2"
+        return super().__getitem__(name)
+
+
 @unique
-class Orbital(Enum):
+class Orbital(Enum, metaclass=_OrbitalMeta):
     """Enum type for specific orbitals. The indices are the order in
     which the orbitals are reported in VASP and has no special meaning.
     """
@@ -63,7 +88,7 @@ class Orbital(Enum):
     dyz = 5
     dz2 = 6
     dxz = 7
-    dx2 = 8
+    dx2_y2 = 8
     f_3 = 9
     f_2 = 10
     f_1 = 11

--- a/src/pymatgen/electronic_structure/core.py
+++ b/src/pymatgen/electronic_structure/core.py
@@ -5,7 +5,7 @@ including Spin, Orbital and Magmom.
 from __future__ import annotations
 
 import warnings
-from enum import Enum, EnumMeta, unique
+from enum import Enum, EnumType, unique
 from typing import TYPE_CHECKING, Literal, cast
 
 import numpy as np
@@ -50,23 +50,23 @@ class OrbitalType(Enum):
         return cast("Literal['s', 'p', 'd', 'f']", str(self.name))
 
 
-class _OrbitalMeta(EnumMeta):
+class _OrbitalMeta(EnumType):
     """Metaclass providing deprecated orbital-name compatibility."""
 
-    def __getattribute__(cls, name: str):
+    def __getattr__(cls, name: str):
         if name == "dx2":
             warnings.warn(
-                "Orbital.dx2 is deprecated; use Orbital.dx2_y2 instead.",
+                "Orbital.dx2 is deprecated; use Orbital.dx2_y2 instead. It will be removed on 2027-08-17.",
                 DeprecationWarning,
                 stacklevel=2,
             )
-            name = "dx2_y2"
-        return super().__getattribute__(name)
+            return cls.dx2_y2
+        raise AttributeError(name)
 
     def __getitem__(cls, name: str):
         if name == "dx2":
             warnings.warn(
-                "The 'dx2' orbital name is deprecated; use 'dx2_y2' instead.",
+                "The 'dx2' orbital name is deprecated; use 'dx2_y2' instead. It will be removed on 2027-08-17.",
                 DeprecationWarning,
                 stacklevel=2,
             )

--- a/src/pymatgen/electronic_structure/core.py
+++ b/src/pymatgen/electronic_structure/core.py
@@ -61,7 +61,10 @@ class _OrbitalMeta(EnumType):
                 stacklevel=2,
             )
             return cls.dx2_y2
-        raise AttributeError(name)
+        try:
+            return super().__getattr__(name)  # type: ignore[misc]
+        except AttributeError:
+            raise AttributeError(name) from None
 
     def __getitem__(cls, name: str):
         if name == "dx2":

--- a/src/pymatgen/electronic_structure/dos.py
+++ b/src/pymatgen/electronic_structure/dos.py
@@ -1387,27 +1387,26 @@ class CompleteDos(Dos):
         tdos = Dos.from_dict(dct)
         struct = Structure.from_dict(dct["structure"])
         pdoss = {}
-        warned_legacy_dx2 = False
         for idx in range(len(dct["pdos"])):
             at = struct[idx]
             orb_dos = {}
+            # TODO(2027-08-17): Remove legacy "dx2" deserialization.
             for orb_str, odos in dct["pdos"][idx].items():
-                if orb_str == "dx2":
-                    if not warned_legacy_dx2:
-                        warnings.warn(
-                            "The 'dx2' orbital name in serialized DOS data is deprecated; use 'dx2_y2' instead.",
-                            DeprecationWarning,
-                            stacklevel=2,
-                        )
-                        warned_legacy_dx2 = True
-                    orb_str = "dx2_y2"
-                orb = Orbital[orb_str]
+                orb = Orbital["dx2_y2" if orb_str == "dx2" else orb_str]
                 orb_dos[orb] = {Spin(int(k)): v for k, v in odos["densities"].items()}
             pdoss[at] = orb_dos
         return cls(struct, tdos, pdoss)
 
     def as_dict(self) -> dict[str, Any]:
         """JSON-serializable dict representation of CompleteDos."""
+        # TODO(2027-08-17): Serialize canonical "dx2_y2" names and remove this compatibility warning.
+        if any(Orbital.dx2_y2 in site_pdos for site_pdos in self.pdos.values()):
+            warnings.warn(
+                "CompleteDos.as_dict() temporarily serializes 'dx2_y2' as 'dx2' for backward compatibility. "
+                "It will serialize 'dx2_y2' on or after 2027-08-17.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         dct = {
             "@module": type(self).__module__,
             "@class": type(self).__name__,
@@ -1421,7 +1420,8 @@ class CompleteDos(Dos):
             for at in self.structure:
                 dd = {}
                 for orb, pdos in self.pdos[at].items():
-                    dd[str(orb)] = {"densities": {str(int(spin)): list(dens) for spin, dens in pdos.items()}}  # type:ignore[arg-type]
+                    orb_name = "dx2" if orb is Orbital.dx2_y2 else str(orb)
+                    dd[orb_name] = {"densities": {str(int(spin)): list(dens) for spin, dens in pdos.items()}}  # type:ignore[arg-type]
                 dct["pdos"].append(dd)
             dct["atom_dos"] = {str(at): dos.as_dict() for at, dos in self.get_element_dos().items()}
             dct["spd_dos"] = {str(orb): dos.as_dict() for orb, dos in self.get_spd_dos().items()}

--- a/src/pymatgen/electronic_structure/dos.py
+++ b/src/pymatgen/electronic_structure/dos.py
@@ -1387,10 +1387,20 @@ class CompleteDos(Dos):
         tdos = Dos.from_dict(dct)
         struct = Structure.from_dict(dct["structure"])
         pdoss = {}
+        warned_legacy_dx2 = False
         for idx in range(len(dct["pdos"])):
             at = struct[idx]
             orb_dos = {}
             for orb_str, odos in dct["pdos"][idx].items():
+                if orb_str == "dx2":
+                    if not warned_legacy_dx2:
+                        warnings.warn(
+                            "The 'dx2' orbital name in serialized DOS data is deprecated; use 'dx2_y2' instead.",
+                            DeprecationWarning,
+                            stacklevel=2,
+                        )
+                        warned_legacy_dx2 = True
+                    orb_str = "dx2_y2"
                 orb = Orbital[orb_str]
                 orb_dos[orb] = {Spin(int(k)): v for k, v in odos["densities"].items()}
             pdoss[at] = orb_dos

--- a/src/pymatgen/electronic_structure/dos.py
+++ b/src/pymatgen/electronic_structure/dos.py
@@ -1399,14 +1399,7 @@ class CompleteDos(Dos):
 
     def as_dict(self) -> dict[str, Any]:
         """JSON-serializable dict representation of CompleteDos."""
-        # TODO(2027-08-17): Serialize canonical "dx2_y2" names and remove this compatibility warning.
-        if any(Orbital.dx2_y2 in site_pdos for site_pdos in self.pdos.values()):
-            warnings.warn(
-                "CompleteDos.as_dict() temporarily serializes 'dx2_y2' as 'dx2' for backward compatibility. "
-                "It will serialize 'dx2_y2' on or after 2027-08-17.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
+        # TODO(2027-08-17): Serialize canonical "dx2_y2" names instead of the legacy "dx2" key.
         dct = {
             "@module": type(self).__module__,
             "@class": type(self).__name__,

--- a/src/pymatgen/electronic_structure/dos.py
+++ b/src/pymatgen/electronic_structure/dos.py
@@ -782,7 +782,7 @@ class CompleteDos(Dos):
                 for orb, pdos in atom_dos.items():
                     if orb in (Orbital.dxy, Orbital.dxz, Orbital.dyz):
                         t2g_dos.append(pdos)
-                    elif orb in (Orbital.dx2, Orbital.dz2):
+                    elif orb in (Orbital.dx2_y2, Orbital.dz2):
                         eg_dos.append(pdos)
         return {
             "t2g": Dos(self.efermi, self.energies, functools.reduce(add_densities, t2g_dos)),
@@ -1486,7 +1486,7 @@ class LobsterCompleteDos(CompleteDos):
 
                     if orbital in (Orbital.dxy, Orbital.dxz, Orbital.dyz):
                         t2g_dos.append(pdos)
-                    elif orbital in (Orbital.dx2, Orbital.dz2):
+                    elif orbital in (Orbital.dx2_y2, Orbital.dz2):
                         eg_dos.append(pdos)
         return {
             "t2g": Dos(self.efermi, self.energies, functools.reduce(add_densities, t2g_dos)),

--- a/src/pymatgen/electronic_structure/plotter.py
+++ b/src/pymatgen/electronic_structure/plotter.py
@@ -1302,7 +1302,7 @@ class BSPlotterProjected(BSPlotter):
             "dyz": 5,
             "dz2": 6,
             "dxz": 7,
-            "dx2": 8,
+            "dx2_y2": 8,
             "f_3": 9,
             "f_2": 10,
             "f_1": 11,
@@ -1657,7 +1657,7 @@ class BSPlotterProjected(BSPlotter):
             character for the corresponding elements
             and orbitals. List of individual orbitals and their numbers (set up
             by VASP and no special meaning):
-            s = 0; py = 1 pz = 2 px = 3; dxy = 4 dyz = 5 dz2 = 6 dxz = 7 dx2 = 8;
+            s = 0; py = 1 pz = 2 px = 3; dxy = 4 dyz = 5 dz2 = 6 dxz = 7 dx2_y2 = 8;
             f_3 = 9 f_2 = 10 f_1 = 11 f0 = 12 f1 = 13 f2 = 14 f3 = 15
         """
         dictio, sum_morbs = self._Orbitals_SumOrbitals(dictio, sum_morbs)
@@ -1775,7 +1775,7 @@ class BSPlotterProjected(BSPlotter):
             "dxy",
             "dyz",
             "dxz",
-            "dx2",
+            "dx2_y2",
             "dz2",
             "f_3",
             "f_2",
@@ -1787,7 +1787,7 @@ class BSPlotterProjected(BSPlotter):
         ]
         individual_orbs = {
             "p": ["px", "py", "pz"],
-            "d": ["dxy", "dyz", "dxz", "dx2", "dz2"],
+            "d": ["dxy", "dyz", "dxz", "dx2_y2", "dz2"],
             "f": ["f_3", "f_2", "f_1", "f0", "f1", "f2", "f3"],
         }
 
@@ -2044,7 +2044,7 @@ class BSPlotterProjected(BSPlotter):
     def _summarize_keys_for_plot(self, dictio, dictpa, sum_atoms, sum_morbs):
         individual_orbs = {
             "p": ["px", "py", "pz"],
-            "d": ["dxy", "dyz", "dxz", "dx2", "dz2"],
+            "d": ["dxy", "dyz", "dxz", "dx2_y2", "dz2"],
             "f": ["f_3", "f_2", "f_1", "f0", "f1", "f2", "f3"],
         }
 

--- a/src/pymatgen/io/cp2k/outputs.py
+++ b/src/pymatgen/io/cp2k/outputs.py
@@ -1725,7 +1725,7 @@ def parse_pdos(dos_file=None, spin_channel=None, total=False):
             if label == "d+1":
                 return "dxz"
             if label == "d+2":
-                return "dx2"
+                return "dx2_y2"
             if label == "f-3":
                 return "f_3"
             if label == "f-2":

--- a/src/pymatgen/io/jdftx/_output_utils.py
+++ b/src/pymatgen/io/jdftx/_output_utils.py
@@ -555,7 +555,7 @@ orb_ref_to_o_dict = {
     "dyz": int(Orbital.dyz),
     "dz2": int(Orbital.dz2),
     "dxz": int(Orbital.dxz),
-    "dx2-y2": int(Orbital.dx2),
+    "dx2-y2": int(Orbital.dx2_y2),
     # Keep the f-orbitals arbitrary-ish until they get designated names in pymatgen.
     orb_ref_list[-1][0]: int(Orbital.f_3),
     orb_ref_list[-1][1]: int(Orbital.f_2),

--- a/src/pymatgen/io/vasp/outputs.py
+++ b/src/pymatgen/io/vasp/outputs.py
@@ -7491,7 +7491,7 @@ class Vaspout(Vasprun):
 
         # for whatever reason, the naming of orbitals is different in vaspout.h5
         vasp_to_pmg_orb = {
-            "x2-y2": "dx2",
+            "x2-y2": "dx2_y2",
             "fy3x2": "f_3",
             "fxyz": "f_2",
             "fyz2": "f_1",

--- a/tests/electronic_structure/test_bandstructure.py
+++ b/tests/electronic_structure/test_bandstructure.py
@@ -233,8 +233,9 @@ class TestBandStructureSymmLine(MatSciTest):
     def test_old_format_load(self):
         with open(f"{TEST_DIR}/bs_ZnS_old.json", "rb") as file:
             dct = orjson.loads(file.read())
+        with pytest.warns(DeprecationWarning, match="'dx2' orbital name"):
             bs_old = BandStructureSymmLine.from_dict(dct)
-            assert bs_old.get_projection_on_elements()[Spin.up][0][0]["Zn"] == approx(0.0971)
+        assert bs_old.get_projection_on_elements()[Spin.up][0][0]["Zn"] == approx(0.0971)
 
     def test_apply_scissor_insulator(self):
         # test applying a scissor operator to a metal

--- a/tests/electronic_structure/test_cohp.py
+++ b/tests/electronic_structure/test_cohp.py
@@ -982,15 +982,13 @@ class TestCompleteCohp(MatSciTest):
         with warnings.catch_warnings():
             warnings.simplefilter("error", DeprecationWarning)
             cohp = CompleteCohp.from_dict(dct)
-        with pytest.warns(DeprecationWarning, match=r"CompleteCohp\.as_dict\(\).*2027-08-17"):
-            cohp_dict = cohp.as_dict()
+        cohp_dict = cohp.as_dict()
         assert all("dx2_y2" not in orb for orb in cohp_dict["orb_res_cohp"]["49"])
 
         with warnings.catch_warnings():
             warnings.simplefilter("error", DeprecationWarning)
             round_trip_cohp = CompleteCohp.from_dict(cohp_dict)
-        with pytest.warns(DeprecationWarning, match=r"CompleteCohp\.as_dict\(\).*2027-08-17"):
-            assert round_trip_cohp.as_dict() == cohp_dict
+        assert round_trip_cohp.as_dict() == cohp_dict
 
         legacy_label = next(orb for orb in cohp_dict["orb_res_cohp"]["49"] if "dx2" in orb)
         canonical_label = legacy_label.replace("dx2", "dx2_y2")

--- a/tests/electronic_structure/test_cohp.py
+++ b/tests/electronic_structure/test_cohp.py
@@ -974,6 +974,15 @@ class TestCompleteCohp(MatSciTest):
         #             if bond != "average":
         #                 assert cohp_lmto_dict[key][bond] == self.cohp_lmto_dict.as_dict()[key][bond]
 
+    def test_legacy_dx2_orbital_name(self):
+        with open(f"{TEST_DIR}/complete_cohp_forb.json", "rb") as file:
+            dct = orjson.loads(file.read())
+        with pytest.warns(DeprecationWarning, match="'dx2' orbital name"):
+            cohp = CompleteCohp.from_dict(dct)
+        cohp_dict = cohp.as_dict()
+        assert all("dx2-" not in orb for orb in cohp_dict["orb_res_cohp"]["49"])
+        assert CompleteCohp.from_dict(cohp_dict).as_dict() == cohp_dict
+
     def test_icohp_values(self):
         # icohp_ef are the ICHOP(Ef) values taken from
         # the ICOHPLIST.lobster file.

--- a/tests/electronic_structure/test_cohp.py
+++ b/tests/electronic_structure/test_cohp.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import warnings
+
 import orjson
 import pytest
 from numpy.testing import assert_allclose
@@ -977,11 +979,31 @@ class TestCompleteCohp(MatSciTest):
     def test_legacy_dx2_orbital_name(self):
         with open(f"{TEST_DIR}/complete_cohp_forb.json", "rb") as file:
             dct = orjson.loads(file.read())
-        with pytest.warns(DeprecationWarning, match="'dx2' orbital name"):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
             cohp = CompleteCohp.from_dict(dct)
-        cohp_dict = cohp.as_dict()
-        assert all("dx2-" not in orb for orb in cohp_dict["orb_res_cohp"]["49"])
-        assert CompleteCohp.from_dict(cohp_dict).as_dict() == cohp_dict
+        with pytest.warns(DeprecationWarning, match=r"CompleteCohp\.as_dict\(\).*2027-08-17"):
+            cohp_dict = cohp.as_dict()
+        assert all("dx2_y2" not in orb for orb in cohp_dict["orb_res_cohp"]["49"])
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            round_trip_cohp = CompleteCohp.from_dict(cohp_dict)
+        with pytest.warns(DeprecationWarning, match=r"CompleteCohp\.as_dict\(\).*2027-08-17"):
+            assert round_trip_cohp.as_dict() == cohp_dict
+
+        legacy_label = next(orb for orb in cohp_dict["orb_res_cohp"]["49"] if "dx2" in orb)
+        canonical_label = legacy_label.replace("dx2", "dx2_y2")
+        mixed_label = f"{legacy_label}-{canonical_label}"
+        orbital_data = cohp_dict["orb_res_cohp"]["49"].pop(legacy_label)
+        for orbital in orbital_data["orbitals"]:
+            if orbital[1] == "dx2":
+                orbital[1] = "dx2_y2"
+        cohp_dict["orb_res_cohp"]["49"][mixed_label] = orbital_data
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            canonical_cohp = CompleteCohp.from_dict(cohp_dict)
+        assert f"{canonical_label}-{canonical_label}" in canonical_cohp.orb_res_cohp["49"]
 
     def test_icohp_values(self):
         # icohp_ef are the ICHOP(Ef) values taken from

--- a/tests/electronic_structure/test_core.py
+++ b/tests/electronic_structure/test_core.py
@@ -40,10 +40,14 @@ class TestOrbital:
         assert Orbital["dx2_y2"] is Orbital.dx2_y2
 
     def test_deprecated_dx2_name(self):
-        with pytest.warns(DeprecationWarning, match="Orbital.dx2 is deprecated"):
+        with pytest.warns(DeprecationWarning, match=r"Orbital\.dx2 is deprecated.*2027-08-17"):
             assert Orbital.dx2 is Orbital.dx2_y2
-        with pytest.warns(DeprecationWarning, match="'dx2' orbital name is deprecated"):
+        with pytest.warns(DeprecationWarning, match=r"'dx2' orbital name is deprecated.*2027-08-17"):
             assert Orbital["dx2"] is Orbital.dx2_y2
+
+    def test_unknown_orbital_attribute(self):
+        with pytest.raises(AttributeError, match="not_an_orbital"):
+            _ = Orbital.not_an_orbital
 
 
 class TestMagmom:

--- a/tests/electronic_structure/test_core.py
+++ b/tests/electronic_structure/test_core.py
@@ -34,6 +34,17 @@ class TestOrbital:
     def test_cached(self):
         assert id(Orbital(0)) == id(Orbital.s)
 
+    def test_dx2_y2_name(self):
+        assert Orbital.dx2_y2.value == 8
+        assert str(Orbital.dx2_y2) == "dx2_y2"
+        assert Orbital["dx2_y2"] is Orbital.dx2_y2
+
+    def test_deprecated_dx2_name(self):
+        with pytest.warns(DeprecationWarning, match="Orbital.dx2 is deprecated"):
+            assert Orbital.dx2 is Orbital.dx2_y2
+        with pytest.warns(DeprecationWarning, match="'dx2' orbital name is deprecated"):
+            assert Orbital["dx2"] is Orbital.dx2_y2
+
 
 class TestMagmom:
     def test_init(self):

--- a/tests/electronic_structure/test_dos.py
+++ b/tests/electronic_structure/test_dos.py
@@ -216,8 +216,7 @@ class TestCompleteDos:
         assert_allclose(sum_spd.energies, sum_element.energies, atol=1e-4)
 
     def test_legacy_dx2_orbital_name(self):
-        with pytest.warns(DeprecationWarning, match=r"CompleteDos\.as_dict\(\).*2027-08-17"):
-            dct = self.dos.as_dict()
+        dct = self.dos.as_dict()
         pdos = next(site_pdos for site_pdos in dct["pdos"] if "dx2" in site_pdos)
         assert "dx2_y2" not in pdos
 

--- a/tests/electronic_structure/test_dos.py
+++ b/tests/electronic_structure/test_dos.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import gzip
 import re
+import warnings
 
 import numpy as np
 import orjson
@@ -215,12 +216,21 @@ class TestCompleteDos:
         assert_allclose(sum_spd.energies, sum_element.energies, atol=1e-4)
 
     def test_legacy_dx2_orbital_name(self):
-        dct = self.dos.as_dict()
-        pdos = next(site_pdos for site_pdos in dct["pdos"] if "dx2_y2" in site_pdos)
-        pdos["dx2"] = pdos.pop("dx2_y2")
-        with pytest.warns(DeprecationWarning, match="'dx2' orbital name"):
+        with pytest.warns(DeprecationWarning, match=r"CompleteDos\.as_dict\(\).*2027-08-17"):
+            dct = self.dos.as_dict()
+        pdos = next(site_pdos for site_pdos in dct["pdos"] if "dx2" in site_pdos)
+        assert "dx2_y2" not in pdos
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
             dos = CompleteDos.from_dict(dct)
         assert any(Orbital.dx2_y2 in orbital_dos for orbital_dos in dos.pdos.values())
+
+        pdos["dx2_y2"] = pdos.pop("dx2")
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            canonical_dos = CompleteDos.from_dict(dct)
+        assert any(Orbital.dx2_y2 in orbital_dos for orbital_dos in canonical_dos.pdos.values())
 
     def test_str(self):
         assert str(self.dos).startswith("Complete DOS for Full Formula (Li1 Fe4 P4 O16)\nReduced Formula: LiFe4(PO4)4")

--- a/tests/electronic_structure/test_dos.py
+++ b/tests/electronic_structure/test_dos.py
@@ -214,6 +214,14 @@ class TestCompleteDos:
         # The sums of the SPD or the element doses should be the same.
         assert_allclose(sum_spd.energies, sum_element.energies, atol=1e-4)
 
+    def test_legacy_dx2_orbital_name(self):
+        dct = self.dos.as_dict()
+        pdos = next(site_pdos for site_pdos in dct["pdos"] if "dx2_y2" in site_pdos)
+        pdos["dx2"] = pdos.pop("dx2_y2")
+        with pytest.warns(DeprecationWarning, match="'dx2' orbital name"):
+            dos = CompleteDos.from_dict(dct)
+        assert any(Orbital.dx2_y2 in orbital_dos for orbital_dos in dos.pdos.values())
+
     def test_str(self):
         assert str(self.dos).startswith("Complete DOS for Full Formula (Li1 Fe4 P4 O16)\nReduced Formula: LiFe4(PO4)4")
 

--- a/tests/io/lobster/test_outputs.py
+++ b/tests/io/lobster/test_outputs.py
@@ -333,7 +333,7 @@ class TestCohpcar(MatSciTest):
             *["f_1"] * 4,
             *["f_2"] * 4,
             *["f_3"] * 4,
-            *["dx2"] * 4,
+            *["dx2_y2"] * 4,
             *["dxy"] * 4,
             *["dxz"] * 4,
             *["dyz"] * 4,


### PR DESCRIPTION
close https://github.com/materialsproject/pymatgen/issues/4588

previously https://github.com/materialsproject/pymatgen/pull/4590

## Breaking Changes

`Orbital.dx2` is renamed to `Orbital.dx2_y2` (enum value `8` unchanged). To avoid breaking consumers of serialized data, this is a two-phase transition:

- **Until 2027-08-17:** `Orbital.dx2` / `Orbital["dx2"]` still resolve (with a `DeprecationWarning`); `CompleteCohp.as_dict()` / `CompleteDos.as_dict()` still write the legacy `dx2` key; readers accept both `dx2` and `dx2_y2`.
- **From 2027-08-17:** canonical `dx2_y2` is serialized and the legacy alias/read paths are removed.

**Migration:** use `Orbital.dx2_y2` / `"dx2_y2"`; existing serialized data needs no conversion.

