### PR TITLE
Ask for permission for using uploaded files in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -67,3 +67,13 @@ body:
       description: Please upload relevant files to help reproduce this bug, or logs if helpful.
     validations:
       required: false
+
+  - type: checkboxes
+    id: reproduction-file-license
+    attributes:
+      label: Rights for uploaded reproduction files
+      description: |
+        Do not upload confidential, personal, proprietary, export-controlled, or otherwise restricted data. If maintainers add an uploaded file to the test suite, it will be distributed under this repository's license. Check the box below only if you upload a file and grant this permission.
+      options:
+        - label: >
+            If I upload files, I confirm that I have authority to share them publicly and grant permission to copy, modify, distribute, and sublicense them under this repository's license.


### PR DESCRIPTION
I'm by no means a lawyer, but I think users retain ownership of their uploaded files and pmg might not automatically have the right to add their files to the test suite just because users provided a file during bug report? Previously I have to manually ask the user for permission which was a bit tedious