### PR TITLE
Setters for `Structure.frac_coords` and `Structure.cart_coords`

### DIFF
--- a/src/pymatgen/core/structure.py
+++ b/src/pymatgen/core/structure.py
@@ -4031,12 +4031,22 @@ class Structure(IStructure, collections.abc.MutableSequence):
     @IStructure.frac_coords.setter
     def frac_coords(self, fractional_coords: ArrayLike) -> None:
         """Sets the fractional coordinates of the Sites in the Structure."""
+        if len(fractional_coords) != len(self.sites):
+            raise ValueError(
+                "A Structure must have as many coordinates as it has sites, "
+                f"{len(fractional_coords)=} != {len(self.sites)=}."
+            )
         for i, site in enumerate(self.sites):
             site.frac_coords = np.asarray(fractional_coords[i], dtype=np.float64)
 
     @IStructure.cart_coords.setter
     def cart_coords(self, cartesian_coords: ArrayLike) -> None:
         """Sets the cartesian coordinates of the Sites in the Structure."""
+        if len(cartesian_coords) != len(self.sites):
+            raise ValueError(
+                "A Structure must have as many coordinates as it has sites, "
+                f"{len(cartesian_coords)=} != {len(self.sites)=}."
+            )
         for i, site in enumerate(self.sites):
             site.coords = np.asarray(cartesian_coords[i], dtype=np.float64)
 

--- a/src/pymatgen/core/structure.py
+++ b/src/pymatgen/core/structure.py
@@ -4028,6 +4028,18 @@ class Structure(IStructure, collections.abc.MutableSequence):
         """Delete a site from the Structure."""
         self._sites.__delitem__(idx)
 
+    @IStructure.frac_coords.setter
+    def frac_coords(self, fractional_coords: ArrayLike) -> None:
+        """Sets the fractional coordinates of the Sites in the Structure."""
+        for i, site in enumerate(self.sites):
+            site.frac_coords = np.asarray(fractional_coords[i], dtype=np.float64)
+
+    @IStructure.cart_coords.setter
+    def cart_coords(self, cartesian_coords: ArrayLike) -> None:
+        """Sets the cartesian coordinates of the Sites in the Structure."""
+        for i, site in enumerate(self.sites):
+            site.coords = np.asarray(cartesian_coords[i], dtype=np.float64)
+
     @property
     def lattice(self) -> Lattice:
         """Lattice associated with structure."""
@@ -4394,7 +4406,7 @@ class Structure(IStructure, collections.abc.MutableSequence):
 
     def translate_sites(
         self,
-        indices: int | Sequence[int],
+        indices: int | Iterable[int],
         vector: ArrayLike,
         frac_coords: bool = True,
         to_unit_cell: bool = True,
@@ -4403,13 +4415,13 @@ class Structure(IStructure, collections.abc.MutableSequence):
         unit cell. Modifies the structure in place.
 
         Args:
-            indices: Integer or List of site indices on which to perform the
+            indices: Integer or iterable of site indices on which to perform the
                 translation.
             vector: Translation vector for sites.
             frac_coords (bool): Whether the vector corresponds to fractional or
                 Cartesian coordinates.
-            to_unit_cell (bool): Whether new sites are transformed to unit
-                cell
+            to_unit_cell (bool): Whether the new coordinates are transformed to the unit
+                cell.
 
         Returns:
             Structure: self with translated sites.

--- a/tests/core/test_structure.py
+++ b/tests/core/test_structure.py
@@ -1115,6 +1115,12 @@ class TestStructure(MatSciTest):
         coords = np.array([[0.1, 0.5, 0.9], [0.5, 1.0, 1.5], [1.9, 1.3, 0.8]], dtype=np.float64)
         struct.cart_coords = coords
         assert np.allclose(struct.cart_coords, coords)
+
+        # Addition of a vector should add this vector to all coordinates (same as numpy array)
+        vector = np.array([0, 0.5, 0], dtype=np.float64)
+        struct.cart_coords += vector
+        assert np.allclose(struct.cart_coords, coords + vector)
+
         f_coords = np.array([[0.1, 0.1, 0.1], [0.6, 0.6, 0.6], [0.9, 0.9, 0.9]], dtype=np.float64)
         struct.frac_coords = f_coords
         assert np.allclose(struct.frac_coords, f_coords)

--- a/tests/core/test_structure.py
+++ b/tests/core/test_structure.py
@@ -1109,6 +1109,23 @@ class TestStructure(MatSciTest):
         struct[:2] = "S"
         assert struct.formula == "Li1 S2"
 
+    def test_coord_setters(self):
+        """The coordinate setters should set the coordinates for all sites."""
+        struct = Structure(Lattice.cubic(2), ["H", "He", "Li"], np.zeros((3, 3)))
+        coords = np.array([[0.1, 0.5, 0.9], [0.5, 1.0, 1.5], [1.9, 1.3, 0.8]], dtype=np.float64)
+        struct.cart_coords = coords
+        assert np.allclose(struct.cart_coords, coords)
+        f_coords = np.array([[0.1, 0.1, 0.1], [0.6, 0.6, 0.6], [0.9, 0.9, 0.9]], dtype=np.float64)
+        struct.frac_coords = f_coords
+        assert np.allclose(struct.frac_coords, f_coords)
+
+        bad_coord = np.zeros((2, 3))
+        # Unequal sizes should fail
+        with pytest.raises(ValueError, match="as many coordinates as it has sites"):
+            struct.cart_coords = bad_coord
+        with pytest.raises(ValueError, match="as many coordinates as it has sites"):
+            struct.frac_coords = bad_coord
+
     def test_not_hashable(self):
         with pytest.raises(TypeError, match="unhashable type: 'Structure'"):
             _ = {self.struct: 1}


### PR DESCRIPTION
Currently, changing all coordinates in a Structure requires either manually looping over all sites, or using one of the functions made for specific tasks. One example for this is a simple translation of all sites by a constant (vector), which `translate_sites` can be used for. But that requires an iterable of all site indices (or, to follow the previous typing: a sequence of them), which is unnecessary, if all sites are modified.

Assuming no PBC is needed, this change simplifies such a translation to the following intuitive format:
```py
structure.cart_coords += vector
```

In the same way, more complex modifications of the whole coordinate array are enabled.
Once #50 is merged, this can be simplified further (with a less insignificant performance benefit than right now), as no looping would be needed (given the entire array can then be accessed at once). This change means the coordinate arrays act even more like normal arrays.

The setters check for an equal length between the set coordinates and the new coordinates, as I doubt anyone would want to intentionally pass a smaller coordinate array to only modify the first coordinates (and longer coordinates would remain unused).
The per-coordinate validation from #92 should also work with this change.


## Checklist

- [x] Google format doc strings added. Check with `ruff`.
- [x] Type annotations included. Check with `mypy`.
- [x] Tests added for new features/fixes.