### PR TITLE
Overhaul `get_symmetrically_distinct_miller_indices`

### DIFF
--- a/src/pymatgen/core/lattice.py
+++ b/src/pymatgen/core/lattice.py
@@ -1740,7 +1740,7 @@ class Lattice(MSONable):
         to be used for hkl transformations.
 
         Args:
-            symprec: default is 0.001.
+            symprec: default is 0.01.
         """
         recp_lattice = self.reciprocal_lattice_crystallographic
         # Get symmetry operations from input conventional unit cell

--- a/src/pymatgen/core/structure.py
+++ b/src/pymatgen/core/structure.py
@@ -1052,9 +1052,9 @@ class IStructure(SiteCollection, MSONable):
                 ii. List of dict of elements/species and occupancies, e.g.
                     [{"Fe" : 0.5, "Mn":0.5}, ...]. This allows the setup of
                     disordered structures.
-            coords (Nx3 array): list of fractional/Cartesian coordinates of
+            coords (Nx3 array): Array of fractional/Cartesian coordinates of
                 each species.
-            charge (int): overall charge of the structure. Defaults to behavior
+            charge (int): Overall charge of the structure. Defaults to behavior
                 in SiteCollection where total charge is the sum of the oxidation
                 states.
             validate_proximity (bool): Whether to check if there are sites
@@ -3922,9 +3922,9 @@ class Structure(IStructure, collections.abc.MutableSequence):
                 ii. List of dict of elements/species and occupancies, e.g.
                     [{"Fe" : 0.5, "Mn":0.5}, ...]. This allows the setup of
                     disordered structures.
-            coords (Nx3 array): list of fractional/cartesian coordinates of
+            coords (Nx3 array): Array of fractional/cartesian coordinates of
                 each species.
-            charge (float): overall charge of the structure. Defaults to behavior
+            charge (float): Overall charge of the structure. Defaults to behavior
                 in SiteCollection where total charge is the sum of the oxidation
                 states.
             validate_proximity (bool): Whether to check if there are sites

--- a/src/pymatgen/core/surface.py
+++ b/src/pymatgen/core/surface.py
@@ -2120,12 +2120,19 @@ def get_symmetrically_distinct_miller_indices(
             with indices to the same maximum absolute index being sorted by ascending absolute sum over hkl.
     """
 
-    def hkl_sort(hkl: tuple[int, int, int]):
-        """Returns a deterministic sorting key for hkl lists."""
-        h = abs(hkl[0])
-        k = abs(hkl[1])
-        L = abs(hkl[2])
-        return (max(h, k, L), h + k + L, hkl)
+    def hkl_key(hkl: tuple[int, int, int]) -> tuple[int, int, int, int, int]:
+        """Returns a deterministic sorting key for hkl tuples.
+
+        This key was chosen to prefer smaller absolute maximum values and
+        First: Lower maximum absolute index (e. g. (100) over (200)).
+        Second: Lower sum of absolute values (e. g. (100) over (110)).
+        Then: Highest value in h, then k, then l (e. g. (100) over (-100)/(010)).
+        """
+        h, k, L = hkl
+        ah = abs(h)
+        ak = abs(k)
+        al = abs(L)
+        return (max(ah, ak, al), ah + ak + al, -h, -k, -L)
 
     sga = SpacegroupAnalyzer(structure)
     # Transform the cell as requested
@@ -2186,10 +2193,10 @@ def get_symmetrically_distinct_miller_indices(
     # Sort by the maximum absolute values of Miller indices so that low-index planes come first.
     # Inside a maximum index, sort by lowest absolute sum so simpler planes come first.
     # This is also relevant to get the smallest-index representation (see pymatgen#2944/2949)
-    # By adding hkl itself as a third key, candidate_hkl has an explicit order
-    candidate_hkl.sort(key=hkl_sort)
+    # By adding -hkl itself as a third key, candidate_hkl has an explicit order
+    candidate_hkl.sort(key=hkl_key)
 
-    # Collect all unique hkl
+    # Collect all unique hkl (stays sorted like candidate_hkl is)
     unique_hkl: list[tuple[int, int, int]] = []
     for hkl in candidate_hkl:
         # Non-reduced hkl indices are equal to their smaller form,
@@ -2209,7 +2216,7 @@ def get_symmetrically_distinct_miller_indices(
         p2c_matrix = np.linalg.inv(sga.get_conventional_to_primitive_transformation_matrix())
         unique_hkl = [hkl_transformation(p2c_matrix, hkl) for hkl in unique_hkl]
         # Re-sort, as indices changed
-        unique_hkl.sort(key=hkl_sort)
+        unique_hkl.sort(key=hkl_key)
 
     if return_hkil:
         # hkil only make sense for the hexagonal family

--- a/src/pymatgen/core/surface.py
+++ b/src/pymatgen/core/surface.py
@@ -29,6 +29,7 @@ from scipy.cluster.hierarchy import fcluster, linkage
 from scipy.spatial.distance import squareform
 
 from pymatgen.core import Lattice, PeriodicSite, Structure, get_el_sp
+from pymatgen.core.operations import SymmOp
 from pymatgen.core.structure_matcher import StructureMatcher
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 from pymatgen.util.coord import in_coord_list
@@ -41,7 +42,6 @@ if TYPE_CHECKING:
     from numpy.typing import ArrayLike, NDArray
 
     from pymatgen.core.composition import Element, Species
-    from pymatgen.core.operations import SymmOp
     from pymatgen.core.structure import IStructure
     from pymatgen.symmetry.groups import CrystalSystem
 
@@ -2058,8 +2058,7 @@ def get_symmetrically_distinct_miller_indices(
     structure: Structure | IStructure,
     max_index: int,
     return_hkil: Literal[False] = False,
-    cell: Literal["input", "conventional", "primitive"] = "primitive",
-    primitive_to_conventional: bool = True,
+    cell: Literal["input", "conventional", "primitive", "conv_np", "prim_2conv"] = "input",
 ) -> list[tuple[int, int, int]]: ...
 
 
@@ -2068,8 +2067,7 @@ def get_symmetrically_distinct_miller_indices(
     structure: Structure | IStructure,
     max_index: int,
     return_hkil: Literal[True] = True,
-    cell: Literal["input", "conventional", "primitive"] = "primitive",
-    primitive_to_conventional: bool = True,
+    cell: Literal["input", "conventional", "primitive", "conv_np", "prim_2conv"] = "input",
 ) -> list[tuple[int, int, int, int]]: ...
 
 
@@ -2077,8 +2075,7 @@ def get_symmetrically_distinct_miller_indices(
     structure: Structure | IStructure,
     max_index: int,
     return_hkil: bool = False,
-    cell: Literal["input", "conventional", "primitive"] = "input",
-    primitive_to_conventional: bool = True,
+    cell: Literal["input", "conventional", "primitive", "conv_np", "prim_2conv"] = "input",
 ) -> list[tuple[int, int, int]] | list[tuple[int, int, int, int]]:
     """Find all symmetrically distinct indices below a certain max-index
     for a given structure. Analysis is based on the symmetry of the
@@ -2086,49 +2083,118 @@ def get_symmetrically_distinct_miller_indices(
 
     Args:
         structure (Structure): The input structure.
-        max_index (int): The maximum index. For example, 1 means that
+        max_index (int): The maximum absolute index h/k/l. For example, 1 means that
             (100), (110), and (111) are returned for the cubic structure.
             All other indices are equivalent to one of these.
+            Keep in mind that for hkil, `abs(i) > max_index` is possible.
         return_hkil (bool): Whether to return hkil (True) form of Miller
-            index for hexagonal systems, or hkl (False).
-        cell (Literal["input", "conventional", "primitive"] = "input"): Cell type to base the Miller indices on.
-            With "input" the input structure is used, while with "conventional" or "primitive" a SpacegroupAnalyzer
-            is used to first obtain the conventional standard or primitive standard representation of the structure.
-            The returned miller indices are therefore relative to this cell, with the exception of using
-            `primitive_to_conventional`.
-        primitive_to_conventional (bool = True): Transform the primitive indices back to conventional indices
-            when using `cell == "primitive"`.
-    """
-    # Get a list of all hkls up to the defined maximum
-    # Exclude (0, 0, 0) and linearly dependent multiples
-    indices = range(-max_index, max_index + 1)
-    candidate_hkl = cast("list[tuple[int, int, int]]", list(itertools.product(indices, repeat=3)))
-    # (0, 0, 0) is always present, remove it
-    candidate_hkl.remove((0, 0, 0))
+            index for hexagonal systems, or hkl (False). Only valid for cells in the hexagonal family.
+        cell (Literal["input", "conventional", "primitive", "conv_np", "prim_2conv"] = "conventional"):
+            Cell type to base the Miller indices on.
 
-    # Sort by the maximum absolute values of Miller indices so that
-    # low-index planes come first. This is important for trigonal systems.
-    candidate_hkl = sorted(candidate_hkl, key=lambda x: max(np.abs(x)))
+            "input": Use the structure as given and its direct symmetry operations.
+
+            "conventional": Use the conventional standard structure and its symmetry operations, except if the structure
+            is centered, use the symmetry operations of the primitive standard structure.
+            Use "conv_np" if this centering behaviour is unwanted.
+
+            "primitive": Use the primitive standard structure and its symmetry operations. Note that this means the
+            Miller indices apply to the primitive structure, not its conventional form. Use "prim_2conv" if you need
+            the equivalent conventional indices.
+
+            "conv_np": Use the conventional standard structure and its symmetry operations.
+            This is equivalent to "conventional", except if the conventional cell is centered. In that case,
+            it is treated as a larger cell instead of using the symmetry operations of the primitive cell.
+
+            "prim_2conv": Use the primitive standard structure and its symmetry operations, then convert the unique
+            indices (in the primitive basis) back to conventional indices.
+            Note that this is *not* the same as using "conventional" with the same `max_index`, as the latter will
+            include all distinct miller indices with a *conventional* index up to `max_index`, while the former returns
+            all distinct miller indices with a *primitive* index up to `max_index`
+            (but converted afterwards to conventional).
+
+    Returns:
+        unique_hkl (list[tuple[int, int, int]] | list[tuple[int, int, int, int]]): List of all hk(i)l indices up to
+            `max_index` that are symmetrically distinct. Only includes indices whose first nonzero index is positive.
+            The hk(i)l apply to the cell type as defined by `cell` and are sorted by ascending maximum absolute index,
+            with indices to the same maximum absolute index being sorted by ascending absolute sum over hkl.
+    """
+
+    def hkl_sort(hkl: tuple[int, int, int]):
+        """Returns a deterministic sorting key for hkl lists."""
+        h = abs(hkl[0])
+        k = abs(hkl[1])
+        L = abs(hkl[2])
+        return (max(h, k, L), h + k + L, hkl)
 
     sga = SpacegroupAnalyzer(structure)
     # Transform the cell as requested
     if cell == "input":
         transformed = structure
-    elif cell == "conventional":
+        rec_symm_ops = transformed.lattice.get_recp_symmetry_operation()
+
+    elif cell in {"conventional", "conv_np"}:
         transformed = sga.get_conventional_standard_structure()
-    elif cell == "primitive":
+        # Don't generate primitive if unneeded or unwanted
+        if sga.get_space_group_symbol().startswith("P") or cell == "conv_np":
+            rec_symm_ops = transformed.lattice.get_recp_symmetry_operation()
+
+        # Use symmetry ops from primitive (but keep conventional hkl)
+        else:
+            c2p_matrix = sga.get_conventional_to_primitive_transformation_matrix()
+            p2c_matrix = np.linalg.inv(c2p_matrix)
+
+            primitive_ops = sga.get_primitive_standard_structure().lattice.get_recp_symmetry_operation()
+
+            # Transform primitive ops to conventional lattice
+            rec_symm_ops = []
+            zero = np.zeros(3)
+            for op in primitive_ops:
+                # Conjugate the rotation matrix by the conv2prim matrix
+                # so the rotation applies to the conventional basis
+                rotation_conv = p2c_matrix @ op.rotation_matrix @ c2p_matrix
+
+                # For a valid conventional hkl basis, the rotation should only
+                # contain integer values
+                rounded_rotation = np.rint(rotation_conv)
+
+                if not np.allclose(rotation_conv, rounded_rotation, atol=1e-8):
+                    raise ValueError(
+                        "Failed to convert primitive reciprocal symmetry operation "
+                        "to conventional reciprocal-index operation, as the values were not integer: "
+                        f"Primitive rotation: {op.rotation_matrix}, obtained conventional rotation: {rotation_conv}."
+                    )
+                # Regenerate SymmOp (no translation component)
+                rec_symm_ops.append(
+                    SymmOp.from_rotation_and_translation(
+                        rounded_rotation,
+                        zero,
+                    )
+                )
+
+    elif cell in {"primitive", "prim_2conv"}:
         transformed = sga.get_primitive_standard_structure()
+        rec_symm_ops = transformed.lattice.get_recp_symmetry_operation()
     else:
         raise ValueError(f"Unsupported cell type {cell}.")
 
-    # Uses the reciprocal lattice and a SGA to get rec. sym. ops
-    rec_symm_ops = transformed.lattice.get_recp_symmetry_operation()
+    # Get a list of all hkls up to the defined maximum
+    # Exclude (0, 0, 0) and linearly dependent multiples
+    indices = range(-max_index, max_index + 1)
+    candidate_hkl = cast("list[tuple[int, int, int]]", list(itertools.product(indices, repeat=3)))
+
+    # Sort by the maximum absolute values of Miller indices so that low-index planes come first.
+    # Inside a maximum index, sort by lowest absolute sum so simpler planes come first.
+    # This is also relevant to get the smallest-index representation (see pymatgen#2944/2949)
+    # By adding hkl itself as a third key, candidate_hkl has an explicit order
+    candidate_hkl.sort(key=hkl_sort)
 
     # Collect all unique hkl
     unique_hkl: list[tuple[int, int, int]] = []
     for hkl in candidate_hkl:
         # Non-reduced hkl indices are equal to their smaller form,
         # therefore check that gcd is 1 (gcd is always positive)
+        # GCD also removes (0, 0, 0), as that is gcd 0.
         # Also exclude the negative equivalents, as (hkl) and (-h, -k, -l)
         # are the same set of planes. We keep the one where the first
         # nonzero index is positive.
@@ -2139,18 +2205,20 @@ def get_symmetrically_distinct_miller_indices(
 
     # Transform primitive indices back to conventional, if requested
     # If the spacegroup is not centered, the matrix will not change the values
-    if primitive_to_conventional and cell == "primitive" and not sga.get_space_group_symbol().startswith("P"):
+    if cell == "prim_2conv" and not sga.get_space_group_symbol().startswith("P"):
         p2c_matrix = np.linalg.inv(sga.get_conventional_to_primitive_transformation_matrix())
         unique_hkl = [hkl_transformation(p2c_matrix, hkl) for hkl in unique_hkl]
+        # Re-sort, as indices changed
+        unique_hkl.sort(key=hkl_sort)
 
-    # hkil only make sense for the hexagonal family
     if return_hkil:
+        # hkil only make sense for the hexagonal family
         # For "input" cells we trust the user to know if hkil make sense for them
-        cell_not_conv = cell == "primitive" and not primitive_to_conventional
-        if cell != "input" and (cell_not_conv or sga.get_crystal_family() != "hexagonal"):
+        if cell != "input" and (cell == "primitive" or sga.get_crystal_family() != "hexagonal"):
             warnings.warn(
                 "hkil miller indices for a conventional hexagonal cell were requested, but the cell is in "
-                f"the {sga.get_crystal_family()} family and {' not' if cell_not_conv else ''} conventional.",
+                f"the {sga.get_crystal_family()} family and the indices are "
+                f"{' not' if cell == 'primitive' else ''} conventional.",
                 stacklevel=2,
             )
         return [(h, k, -h - k, L) for (h, k, L) in unique_hkl]

--- a/src/pymatgen/core/surface.py
+++ b/src/pymatgen/core/surface.py
@@ -21,7 +21,7 @@ import math
 import os
 import warnings
 from functools import reduce
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Literal, cast, overload
 
 import numpy as np
 import orjson
@@ -35,12 +35,13 @@ from pymatgen.util.coord import in_coord_list
 from pymatgen.util.due import Doi, due
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Iterable, Sequence
     from typing import Any, Self
 
     from numpy.typing import ArrayLike, NDArray
 
     from pymatgen.core.composition import Element, Species
+    from pymatgen.core.operations import SymmOp
     from pymatgen.core.structure import IStructure
     from pymatgen.symmetry.groups import CrystalSystem
 
@@ -2052,11 +2053,33 @@ def get_symmetrically_equivalent_miller_indices(
     return equivalent_millers
 
 
+@overload
+def get_symmetrically_distinct_miller_indices(
+    structure: Structure | IStructure,
+    max_index: int,
+    return_hkil: Literal[False] = False,
+    cell: Literal["input", "conventional", "primitive"] = "primitive",
+    primitive_to_conventional: bool = True,
+) -> list[tuple[int, int, int]]: ...
+
+
+@overload
+def get_symmetrically_distinct_miller_indices(
+    structure: Structure | IStructure,
+    max_index: int,
+    return_hkil: Literal[True] = True,
+    cell: Literal["input", "conventional", "primitive"] = "primitive",
+    primitive_to_conventional: bool = True,
+) -> list[tuple[int, int, int, int]]: ...
+
+
 def get_symmetrically_distinct_miller_indices(
     structure: Structure | IStructure,
     max_index: int,
     return_hkil: bool = False,
-) -> list:
+    cell: Literal["input", "conventional", "primitive"] = "input",
+    primitive_to_conventional: bool = True,
+) -> list[tuple[int, int, int]] | list[tuple[int, int, int, int]]:
     """Find all symmetrically distinct indices below a certain max-index
     for a given structure. Analysis is based on the symmetry of the
     reciprocal lattice of the structure.
@@ -2068,64 +2091,84 @@ def get_symmetrically_distinct_miller_indices(
             All other indices are equivalent to one of these.
         return_hkil (bool): Whether to return hkil (True) form of Miller
             index for hexagonal systems, or hkl (False).
+        cell (Literal["input", "conventional", "primitive"] = "input"): Cell type to base the Miller indices on.
+            With "input" the input structure is used, while with "conventional" or "primitive" a SpacegroupAnalyzer
+            is used to first obtain the conventional standard or primitive standard representation of the structure.
+            The returned miller indices are therefore relative to this cell, with the exception of using
+            `primitive_to_conventional`.
+        primitive_to_conventional (bool = True): Transform the primitive indices back to conventional indices
+            when using `cell == "primitive"`.
     """
-    # Get a list of all hkls for conventional (including equivalent)
-    rng = list(range(-max_index, max_index + 1))[::-1]
-    conv_hkl_list = [miller for miller in itertools.product(rng, rng, rng) if any(i != 0 for i in miller)]
+    # Get a list of all hkls up to the defined maximum
+    # Exclude (0, 0, 0) and linearly dependent multiples
+    indices = range(-max_index, max_index + 1)
+    candidate_hkl = cast("list[tuple[int, int, int]]", list(itertools.product(indices, repeat=3)))
+    # (0, 0, 0) is always present, remove it
+    candidate_hkl.remove((0, 0, 0))
 
     # Sort by the maximum absolute values of Miller indices so that
     # low-index planes come first. This is important for trigonal systems.
-    conv_hkl_list = sorted(conv_hkl_list, key=lambda x: max(np.abs(x)))
+    candidate_hkl = sorted(candidate_hkl, key=lambda x: max(np.abs(x)))
 
-    # Get distinct hkl planes from the rhombohedral setting if trigonal
-    spg_analyzer = SpacegroupAnalyzer(structure)
-    if spg_analyzer.get_crystal_system() == "trigonal":
-        transf = spg_analyzer.get_conventional_to_primitive_transformation_matrix()
-        miller_list: list[tuple[int, int, int]] = [hkl_transformation(transf, hkl) for hkl in conv_hkl_list]
-        prim_structure = SpacegroupAnalyzer(structure).get_primitive_standard_structure()
-        symm_ops = prim_structure.lattice.get_recp_symmetry_operation()
-
+    sga = SpacegroupAnalyzer(structure)
+    # Transform the cell as requested
+    if cell == "input":
+        transformed = structure
+    elif cell == "conventional":
+        transformed = sga.get_conventional_standard_structure()
+    elif cell == "primitive":
+        transformed = sga.get_primitive_standard_structure()
     else:
-        miller_list = conv_hkl_list
-        symm_ops = structure.lattice.get_recp_symmetry_operation()
+        raise ValueError(f"Unsupported cell type {cell}.")
 
-    unique_millers: list = []
-    unique_millers_conv: list = []
+    # Uses the reciprocal lattice and a SGA to get rec. sym. ops
+    rec_symm_ops = transformed.lattice.get_recp_symmetry_operation()
 
-    for idx, miller in enumerate(miller_list):
-        denom = abs(reduce(math.gcd, miller))  # type: ignore[arg-type]
-        miller = cast("tuple[int, int, int]", tuple(int(idx / denom) for idx in miller))
-        if not _is_in_miller_family(miller, unique_millers, symm_ops):
-            if spg_analyzer.get_crystal_system() == "trigonal":
-                # Now we find the distinct primitive hkls using
-                # the primitive symmetry operations and their
-                # corresponding hkls in the conventional setting
-                unique_millers.append(miller)
-                denom = abs(reduce(math.gcd, conv_hkl_list[idx]))  # type: ignore[arg-type]
-                cmiller = tuple(int(idx / denom) for idx in conv_hkl_list[idx])
-                unique_millers_conv.append(cmiller)
-            else:
-                unique_millers.append(miller)
-                unique_millers_conv.append(miller)
+    # Collect all unique hkl
+    unique_hkl: list[tuple[int, int, int]] = []
+    for hkl in candidate_hkl:
+        # Non-reduced hkl indices are equal to their smaller form,
+        # therefore check that gcd is 1 (gcd is always positive)
+        # Also exclude the negative equivalents, as (hkl) and (-h, -k, -l)
+        # are the same set of planes. We keep the one where the first
+        # nonzero index is positive.
+        if math.gcd(*hkl) != 1 or next(i for i in hkl if i != 0) > 0:
+            continue
+        if not _is_in_miller_family(hkl, unique_hkl, rec_symm_ops):
+            unique_hkl.append(hkl)
 
-    if return_hkil and spg_analyzer.get_crystal_system() in {"trigonal", "hexagonal"}:
-        return [(hkl[0], hkl[1], -1 * hkl[0] - hkl[1], hkl[2]) for hkl in unique_millers_conv]
+    # Transform primitive indices back to conventional, if requested
+    # If the spacegroup is not centered, the matrix will not change the values
+    if primitive_to_conventional and cell == "primitive" and not sga.get_space_group_symbol().startswith("P"):
+        p2c_matrix = np.linalg.inv(sga.get_conventional_to_primitive_transformation_matrix())
+        unique_hkl = [hkl_transformation(p2c_matrix, hkl) for hkl in unique_hkl]
 
-    return unique_millers_conv
+    # hkil only make sense for the hexagonal family
+    if return_hkil:
+        # For "input" cells we trust the user to know if hkil make sense for them
+        cell_not_conv = cell == "primitive" and not primitive_to_conventional
+        if cell != "input" and (cell_not_conv or sga.get_crystal_family() != "hexagonal"):
+            warnings.warn(
+                "hkil miller indices for a conventional hexagonal cell were requested, but the cell is in "
+                f"the {sga.get_crystal_family()} family and {' not' if cell_not_conv else ''} conventional.",
+                stacklevel=2,
+            )
+        return [(h, k, -h - k, L) for (h, k, L) in unique_hkl]
+    return unique_hkl
 
 
 def _is_in_miller_family(
     miller_index: tuple[int, int, int],
     miller_list: Sequence[tuple[int, int, int]],
-    symm_ops: list,
+    symm_ops: Iterable[SymmOp],
 ) -> bool:
     """Helper function to check if the given Miller index belongs
     to the same family of any index in the provided list.
 
     Args:
         miller_index (tuple[int, int, int]): The Miller index to analyze.
-        miller_list (list): List of Miller indices.
-        symm_ops (list): Symmetry operations for a lattice,
+        miller_list (Sequence[tuple[int, int, int]]): Sequence of Miller indices.
+        symm_ops (Iterable[SymmOp]): Symmetry operations for a lattice,
             used to define the indices family.
     """
     return any(in_coord_list(miller_list, op.operate(miller_index)) for op in symm_ops)

--- a/src/pymatgen/core/surface.py
+++ b/src/pymatgen/core/surface.py
@@ -2132,7 +2132,7 @@ def get_symmetrically_distinct_miller_indices(
         # Also exclude the negative equivalents, as (hkl) and (-h, -k, -l)
         # are the same set of planes. We keep the one where the first
         # nonzero index is positive.
-        if math.gcd(*hkl) != 1 or next(i for i in hkl if i != 0) > 0:
+        if math.gcd(*hkl) != 1 or next(i for i in hkl if i != 0) < 0:
             continue
         if not _is_in_miller_family(hkl, unique_hkl, rec_symm_ops):
             unique_hkl.append(hkl)

--- a/src/pymatgen/symmetry/analyzer.py
+++ b/src/pymatgen/symmetry/analyzer.py
@@ -41,7 +41,7 @@ if TYPE_CHECKING:
 
     from pymatgen.core import Element, IStructure, Species
     from pymatgen.core.sites import Site
-    from pymatgen.symmetry.groups import CrystalSystem
+    from pymatgen.symmetry.groups import CrystalFamily, CrystalSystem
     from pymatgen.util.typing import Kpoint
 
     LatticeType = Literal[
@@ -211,7 +211,7 @@ class SpacegroupAnalyzer:
             ValueError: on invalid space group numbers < 1 or > 230.
 
         Returns:
-            str: Crystal system for structure
+            str: Crystal system of the structure.
         """
         n = self._space_group_data.number
 
@@ -219,7 +219,7 @@ class SpacegroupAnalyzer:
         if n != int(n) or not 0 < n < 231:
             raise ValueError(f"Received invalid space group {n}")
 
-        if 0 < n < 3:
+        if n < 3:
             return "triclinic"
         if n < 16:
             return "monoclinic"
@@ -233,22 +233,36 @@ class SpacegroupAnalyzer:
             return "hexagonal"
         return "cubic"
 
-    def get_lattice_type(self) -> LatticeType:
-        """Get the lattice for the structure, e.g. (triclinic, orthorhombic, cubic,
-        etc.). This is the same as the crystal system with the exception of the
-        hexagonal/rhombohedral lattice.
+    def get_crystal_family(self) -> CrystalFamily:
+        """Get the crystal family of the structure.
+
+        Equivalent to the crystal system, except for the trigonal system, which
+        is part of the hexagonal family.
 
         Raises:
             ValueError: on invalid space group numbers < 1 or > 230.
 
         Returns:
-            str: Lattice type for structure
+            str: Crystal family of the structure.
         """
-        spg_num = self._space_group_data.number
         system = self.get_crystal_system()
-        if spg_num in {146, 148, 155, 160, 161, 166, 167}:
-            return "rhombohedral"
         return "hexagonal" if system == "trigonal" else system
+
+    def get_lattice_type(self) -> LatticeType:
+        """Get the lattice for the structure, e.g. (triclinic, orthorhombic, cubic,
+        etc.). This is the same as the crystal family with the exception of the
+        rhombohedral trigonal cells.
+
+        Raises:
+            ValueError: on invalid space group numbers < 1 or > 230.
+
+        Returns:
+            str: Lattice type of the structure.
+        """
+        # R-centered trigonal cells are the rhombohedral lattice type
+        if self.get_space_group_symbol().startswith("R"):
+            return "rhombohedral"
+        return self.get_crystal_family()
 
     def get_pearson_symbol(self) -> str:
         """Get the Pearson symbol for the structure.

--- a/src/pymatgen/symmetry/groups.py
+++ b/src/pymatgen/symmetry/groups.py
@@ -40,6 +40,15 @@ if TYPE_CHECKING:
         "trigonal",
     ]
 
+    CrystalFamily: TypeAlias = Literal[
+        "cubic",
+        "hexagonal",
+        "monoclinic",
+        "orthorhombic",
+        "tetragonal",
+        "triclinic",
+    ]
+
 
 SYMM_DATA = loadfn(os.path.join(os.path.dirname(__file__), "symm_data.json"))
 

--- a/tests/core/test_surface.py
+++ b/tests/core/test_surface.py
@@ -789,7 +789,12 @@ class TestMillerIndexFinder(MatSciTest):
         # Tests to see if the function obtains the known number of unique slabs
 
         indices = get_symmetrically_distinct_miller_indices(self.cscl, 1)
-        assert len(indices) == 3
+        # Check that the positive versions were returned
+        # and that an earlier index is preferred ((100) over (010)/(001))
+        # and that positive indices are preferred ((111) over (1-1-1) etc.)
+        # and that the indices are sorted by absolute sum
+        cubic_exp = [(1, 0, 0), (1, 1, 0), (1, 1, 1)]
+        assert indices == cubic_exp
         indices = get_symmetrically_distinct_miller_indices(self.cscl, 2)
         assert len(indices) == 6
 
@@ -816,30 +821,46 @@ class TestMillerIndexFinder(MatSciTest):
         indices = get_symmetrically_distinct_miller_indices(self.graphite, 2)
         assert len(indices) == 12
 
-        # Now try a trigonal system.
+        # Now try a trigonal system and hkil.
         # Note that a trigonal cell must use cell="conventional" to restore the old behaviour
         # of using the primitive symmetry.
         indices = get_symmetrically_distinct_miller_indices(self.trig_bi, 2, return_hkil=True, cell="conventional")
         assert len(indices) == 17
         assert all(len(hkl) == 4 for hkl in indices)
+        assert all(i == -h - k for h, k, i, _ in indices)
 
         # Test to see if the output with max_index i is a subset of the output with max_index i+1
-        for idx in range(1, 4):
-            assert set(get_symmetrically_distinct_miller_indices(self.trig_bi, idx)) <= set(
-                get_symmetrically_distinct_miller_indices(self.trig_bi, idx + 1)
-            )
+        # Also check that the order of the smaller index values remains unchanged
+        prev: list[tuple[int, int, int]] = []
+        for idx in range(1, 5):
+            new = get_symmetrically_distinct_miller_indices(self.trig_bi, idx)
+            assert prev == new[: len(prev)]
+            prev = new
 
         # Using the conventional symmetry ops will lead to less distinct indices (as there is centering):
         # (the input cell is conventional, so input==conv_np)
-        indices_i = get_symmetrically_distinct_miller_indices(self.trig_bi, 2, return_hkil=True, cell="input")
+        indices_i = get_symmetrically_distinct_miller_indices(self.trig_bi, 2, cell="input")
         assert len(indices_i) == 12
-        indices_np = get_symmetrically_distinct_miller_indices(self.trig_bi, 2, return_hkil=True, cell="conv_np")
+        indices_np = get_symmetrically_distinct_miller_indices(self.trig_bi, 2, cell="conv_np")
         assert indices_i == indices_np
 
         # With primitive symmetry, the count *can* be different (depends on the lattice)
-        indices_p = get_symmetrically_distinct_miller_indices(self.trig_bi, 2, return_hkil=True, cell="primitive")
+        indices_p = get_symmetrically_distinct_miller_indices(self.trig_bi, 2, cell="primitive")
         assert len(indices_p) == 13
         # Count has to be the same with converted indices, but the indices are different
+
+        # Test a non-conventional cell: Supercell of CsCl
+        super_cscl = self.cscl.make_supercell((2, 1, 1), in_place=False)
+        # CsCl is cubic, but this supercell is only tetragonal -> "input" and "conventional" differ
+        # Also, it is expanded in a, not in c - so a is the unique axis!
+        tetra_nonconv_exp = [(1, 0, 0), (0, 1, 0), (1, 1, 0), (0, 1, 1), (1, 1, 1)]
+        assert get_symmetrically_distinct_miller_indices(super_cscl, 1) == tetra_nonconv_exp
+        assert get_symmetrically_distinct_miller_indices(super_cscl, 1, cell="conventional") == cubic_exp
+
+        # With a conventional tetragonal cell, return the planes for a c-unique cell
+        tetra_conv_exp = [(1, 0, 0), (0, 0, 1), (1, 1, 0), (1, 0, 1), (1, 1, 1)]
+        tetra = Structure(Lattice.tetragonal(2, 3), ["H"], [[0, 0, 0]])
+        assert get_symmetrically_distinct_miller_indices(tetra, 1) == tetra_conv_exp
 
     def test_get_symmetrically_equivalent_miller_indices(self):
         # Tests to see if the function obtains all equivalent hkl for cubic (100)

--- a/tests/core/test_surface.py
+++ b/tests/core/test_surface.py
@@ -793,6 +793,14 @@ class TestMillerIndexFinder(MatSciTest):
         indices = get_symmetrically_distinct_miller_indices(self.cscl, 2)
         assert len(indices) == 6
 
+        # For a P... space group, all modes returning conventional indices should
+        # return the same indices (as long as the input cell is standard)
+        p_conv = get_symmetrically_distinct_miller_indices(self.cscl, 2, cell="conventional")
+        p_conv_np = get_symmetrically_distinct_miller_indices(self.cscl, 2, cell="conv_np")
+        p_prim = get_symmetrically_distinct_miller_indices(self.cscl, 2, cell="primitive")
+        p_prim2conv = get_symmetrically_distinct_miller_indices(self.cscl, 2, cell="prim_2conv")
+        assert p_conv == p_conv_np == p_prim == p_prim2conv
+
         assert len(get_symmetrically_distinct_miller_indices(self.lifepo4, 1)) == 7
 
         # The TeI P-1 structure should have 13 unique millers (only inversion
@@ -809,6 +817,8 @@ class TestMillerIndexFinder(MatSciTest):
         assert len(indices) == 12
 
         # Now try a trigonal system.
+        # Note that a trigonal cell must use cell="conventional" to restore the old behaviour
+        # of using the primitive symmetry.
         indices = get_symmetrically_distinct_miller_indices(self.trig_bi, 2, return_hkil=True, cell="conventional")
         assert len(indices) == 17
         assert all(len(hkl) == 4 for hkl in indices)
@@ -818,6 +828,18 @@ class TestMillerIndexFinder(MatSciTest):
             assert set(get_symmetrically_distinct_miller_indices(self.trig_bi, idx)) <= set(
                 get_symmetrically_distinct_miller_indices(self.trig_bi, idx + 1)
             )
+
+        # Using the conventional symmetry ops will lead to less distinct indices (as there is centering):
+        # (the input cell is conventional, so input==conv_np)
+        indices_i = get_symmetrically_distinct_miller_indices(self.trig_bi, 2, return_hkil=True, cell="input")
+        assert len(indices_i) == 12
+        indices_np = get_symmetrically_distinct_miller_indices(self.trig_bi, 2, return_hkil=True, cell="conv_np")
+        assert indices_i == indices_np
+
+        # With primitive symmetry, the count *can* be different (depends on the lattice)
+        indices_p = get_symmetrically_distinct_miller_indices(self.trig_bi, 2, return_hkil=True, cell="primitive")
+        assert len(indices_p) == 13
+        # Count has to be the same with converted indices, but the indices are different
 
     def test_get_symmetrically_equivalent_miller_indices(self):
         # Tests to see if the function obtains all equivalent hkl for cubic (100)

--- a/tests/core/test_surface.py
+++ b/tests/core/test_surface.py
@@ -809,7 +809,7 @@ class TestMillerIndexFinder(MatSciTest):
         assert len(indices) == 12
 
         # Now try a trigonal system.
-        indices = get_symmetrically_distinct_miller_indices(self.trig_bi, 2, return_hkil=True)
+        indices = get_symmetrically_distinct_miller_indices(self.trig_bi, 2, return_hkil=True, cell="conventional")
         assert len(indices) == 17
         assert all(len(hkl) == 4 for hkl in indices)
 


### PR DESCRIPTION
This PR changes `get_symmetrically_distinct_miller_indices` from the ground up to improve it in various ways:
1. `get_symmetrically_distinct_miller_indices` now cleanly and transparently interacts with centered cells. Before, centered cells were primitivized based on the symmetry of the input structure (assumed to be standard, see 2.), except for trigonal structures (see a)). The new `cell` variable allows choosing between different options for this behaviour (see b)). **This changes the default behaviour for trigonal cells** (see c)).
2. Sorting of the indices is now completely deterministic, even against changes to the generator of the full hkl list. In the same way, the sorting has been slightly changed: Indices with smaller maximum absolute h/k/l still come first as before (which is relevant, compare materialsproject/pymatgen#2949), but then the indices with lower sums of absolute h/k/l follow, e. g. instead of [(1, 1, 1), (1, 1, 0), (1, 0, 0)] the cubic indices for max 1 are sorted as [(1, 0, 0), (1, 1, 0), (1, 1, 1)]. If both of those are the same (e. g. (0, 1, 1) and (1, 0, 1)), the larger `h`, then `k`, then `l` values are preferred. Previously, the implicit ordering was smaller maximum absolute h/k/l, then larger `h`, then `k`, then `l` (except for rhombohedral structures, or if a higher-order version of the plane happened to be in the set).
3. With the change in sorting, a potential change in returned `hkl` is possible, the current implementation prefers the value that comes first according to the above index. It was chosen to generally prefer positive indices and to sort the values in a more d_hkl following way. It would be possible to add `-h-k-l` as a third key if positive indices should be preferred even more. Alternatively, d_hkl could be used as the key (but then the pattern is less obvious).
4. A crystal family function was added to the `SpacegroupAnalyzer` (as the hexagonal family are the spacegroups for which hkil is interesting).
5. The typing is more specific and accurately types the return based on if hkil or hkl are requested.
6. If hkil are requested, but unlikely to be useful, a warning is emitted. I am open to removing this warning or changing the conditions, if the current assumptions are suboptimal.
7. Multiple changes were made to improve the performance as well:

- Miller indices with gcd above 1 are automatically excluded, as higher multiples of the same index were previously reduced down to the gcd (with some reliance on int=round)

- Previously, if a trigonal crystal system was detected, the SGA was created again to get a standard structure: https://github.com/materialsproject/pymatgen-core/blob/00104997ce2711c004cb848f56ee04f93a276c66/src/pymatgen/core/surface.py#L2081-L2086 Now, the amount of SGAs created is limited to the necessary amount.
- Previously, the final results list was created twice to handle the trigonal case separately, but the second list remained unused. Now, the trigonal case does not require special handling anymore.

a) Trigonal structures were previously separated out to get the reciprocal symmetry operations from the primitive cell. This actually only affected cells from the space groups with rhombohedral lattices in the expected way, because only they have a non-eye `get_conventional_to_primitive_transformation_matrix()`. As a side-effect the symmetry operations actually apply to the standard structure, meaning a nonstandard input structure returned either indices relating to its own symmetry (non-trigonal cell) or to the conventional standard cell (for the trigonal cells). This behaviour was not explicitly mentioned, see c) for how it is now.

b) Now, instead of the behaviour mentioned in a), there are five options. Note that there is no option that will return the exactly same result as before.
1. `input`: Use the lattice as-is, with all of its (non-spacegroup and centering) (a)symmetries. This is most similar to the previous behaviour, I would even assert that the returned sets of lattice planes are the same (but sometimes the representing lattice plane will be different, e. g. if (2, -1, 2) and (1, 1, 2) are symmetric, now (1, 1, 2) will be the representative instead of (2, -1, 2)). This is why it is the default behaviour. The key difference is trigonal space groups, especially the ones with rhombohedral lattice type. If given in their hexagonal cell, they will return the symmetry for that setting, not the primitive one. Simply transforming the cell beforehand does not do what one may expect, as then the indices belong to the primitive cell (compare `primitive` mode and `conv_np` mode).
2. `conventional`: Use the conventional standard cell to obtain the symmetry operations. For the trigonal cells, this is the closest to the previous behaviour. If the cell is centered, the symmetry operations of the primitive cell are used instead, but the indices apply to the conventional standard cell.
3. `primitive`: Use the primitive standard cell. The symmetry operations and the returned indices thus apply to that cell.
4. `conv_np`: Use the conventional standard cell, and do not use the operations from the primitive cell. It thus differs from `conventional` for centered cells.
5. `prim_2conv`: Use the primitive standard cell (like `primitive`), but convert the indices to indices in the conventional standard cell.

c) The default behaviour change cannot be avoided if we want to fix the behaviour difference between trigonal and all other cells, while not creating a too complex interface. As stated above, `input` is the current standard, even though I personally would choose `conventional`, as that matches the intent of the function more closely. But I believe more people will use the function with non-trigonal cells than trigonal cells, so the default was set to `input`.

I am open to name changes for the options, the current options try to guide users towards the behaviours they probably want (`input`, `conventional`, `primitive`) while adding other options for those with specific requirements.

## Checklist

- [x] Google format doc strings added. Check with `ruff`.
- [x] Type annotations included. Check with `mypy`.
- [x] Tests added for new features/fixes.