### PR TITLE
Allow smaller primitive Slabs, change the scale factor

### DIFF
--- a/src/pymatgen/core/lattice.py
+++ b/src/pymatgen/core/lattice.py
@@ -1011,19 +1011,19 @@ class Lattice(MSONable):
 
         Returns:
             tuple[Lattice, NDArray[np.float_], NDArray[np.float_]]: (aligned_lattice, rotation_matrix, scale_matrix)
-            if a mapping is found. aligned_lattice is a rotated version of other_lattice that
-            has the same lattice parameters, but which is aligned in the
-            coordinate system of this lattice so that translational points
-            match up in 3D. rotation_matrix is the rotation that has to be
-            applied to other_lattice to obtain aligned_lattice, i.e.,
-            aligned_matrix = np.inner(other_lattice, rotation_matrix) and
-            op = SymmOp.from_rotation_and_translation(rotation_matrix)
-            aligned_matrix = op.operate_multi(latt.matrix)
-            Finally, scale_matrix is the integer matrix that expresses
-            aligned_matrix as a linear combination of this
-            lattice, i.e., aligned_matrix = np.dot(scale_matrix, self.matrix)
+                if a mapping is found. aligned_lattice is a rotated version of other_lattice that
+                has the same lattice parameters, but which is aligned in the
+                coordinate system of this lattice so that translational points
+                match up in 3D. rotation_matrix is the rotation that has to be
+                applied to other_lattice to obtain aligned_lattice, i.e.,
+                aligned_matrix = np.inner(other_lattice, rotation_matrix) and
+                op = SymmOp.from_rotation_and_translation(rotation_matrix)
+                aligned_matrix = op.operate_multi(latt.matrix)
+                Finally, scale_matrix is the integer matrix that expresses
+                aligned_matrix as a linear combination of this
+                lattice, i.e., aligned_matrix = np.dot(scale_matrix, self.matrix)
 
-            None is returned if no matches are found.
+                None is returned if no matches are found.
         """
         return next(
             self.find_all_mappings(other_lattice, ltol, atol, skip_rotation_matrix),

--- a/src/pymatgen/core/surface.py
+++ b/src/pymatgen/core/surface.py
@@ -1201,6 +1201,7 @@ class SlabGenerator:
             )
 
             # Ensure lattice a and b is consistent between the OUC and the slab
+            # Gamma remains unchecked, so the surface could diverge even with no allow_smaller_than_ouc
             if self.allow_smaller_than_ouc or (
                 np.isclose(prim_slab_l.a, prim_ouc.lattice.a) and np.isclose(prim_slab_l.b, prim_ouc.lattice.b)
             ):

--- a/src/pymatgen/core/surface.py
+++ b/src/pymatgen/core/surface.py
@@ -152,7 +152,6 @@ class Slab(Structure):
                 lattice.gamma,
             )
 
-            oriented_unit_cell = copy.deepcopy(oriented_unit_cell)
             ouc_lattice = oriented_unit_cell.lattice
             ouc_lattice = Lattice.from_parameters(
                 ouc_lattice.a,
@@ -163,7 +162,7 @@ class Slab(Structure):
                 ouc_lattice.gamma,
             )
 
-            self.oriented_unit_cell: Structure | IStructure = Structure(
+            self.oriented_unit_cell = type(oriented_unit_cell)(
                 ouc_lattice,
                 oriented_unit_cell.species_and_occu,
                 oriented_unit_cell.frac_coords,
@@ -918,6 +917,7 @@ class SlabGenerator:
         primitive: bool = True,
         max_normal_search: int | None = None,
         reorient_lattice: bool = True,
+        allow_smaller_than_ouc: bool = False,
     ) -> None:
         """Calculate the slab scale factor and uses it to generate an
         oriented unit cell (OUC) of the initial structure.
@@ -961,8 +961,14 @@ class SlabGenerator:
                 cell for simulation. Normality is not guaranteed, but the oriented
                 cell will have the c vector as normal as possible to the surface.
                 The max absolute Miller index is usually sufficient.
-            reorient_lattice (bool): reorient the lattice such that
-                the c direction is parallel to the third lattice vector
+            reorient_lattice (bool): Reorient the lattice such that
+                the c direction is parallel to the third lattice vector?
+            allow_smaller_than_ouc (bool = False): Allow slabs that are smaller
+                than the OUC via primitivization? Enables reduction of the OUC and Slab,
+                and also allows the lattice of the slab to diverge from the lattice of the OUC.
+                This is relevant with primitivization, as the used algorithm may only
+                find a different surface cell if the termination is better than in the
+                OUC.
         """
 
         def reduce_vector(vector: tuple[int, ...]) -> tuple[int, ...]:
@@ -1053,7 +1059,7 @@ class SlabGenerator:
 
             slab_scale_factor = np.array(slab_scale_factor)  # type: ignore[assignment]
 
-            # Let's make sure we have a left-handed crystallographic system
+            # Let's make sure we have a right-handed crystallographic system
             if np.linalg.det(slab_scale_factor) < 0:
                 slab_scale_factor *= -1
 
@@ -1074,8 +1080,7 @@ class SlabGenerator:
         # Calculate scale factor
         slab_scale_factor = calculate_scaling_factor()
 
-        single = initial_structure.copy()
-        single.make_supercell(slab_scale_factor)
+        single = initial_structure.make_supercell(slab_scale_factor, in_place=False)
 
         # Calculate the most reduced structure as OUC to minimize calculations
         self.oriented_unit_cell = Structure.from_sites(single, to_unit_cell=True)
@@ -1092,9 +1097,9 @@ class SlabGenerator:
         self.primitive = primitive
         self._normal = normal  # TODO (@DanielYang59): used only in unit test
         self.reorient_lattice = reorient_lattice
+        self.allow_smaller_than_ouc = allow_smaller_than_ouc
 
-        _a, _b, c = self.oriented_unit_cell.lattice.matrix
-        self._proj_height = abs(np.dot(normal, c))
+        self._proj_height = abs(np.dot(normal, self.oriented_unit_cell.lattice.matrix[2]))
 
     def get_slab(
         self,
@@ -1144,7 +1149,7 @@ class SlabGenerator:
         frac_coords[:, 2] /= n_layers
 
         # Duplicate atom layers by stacking along the z-axis
-        all_coords = []
+        all_coords: list[NDArray[np.float64]] = []
         for idx in range(n_layers_slab):
             _frac_coords = frac_coords.copy()
             _frac_coords[:, 2] += idx / n_layers
@@ -1175,35 +1180,41 @@ class SlabGenerator:
         if self.center_slab:
             struct = center_slab(struct)
 
-        ouc = self.oriented_unit_cell.copy()
-
+        ouc = self.oriented_unit_cell
         # Reduce to primitive cell
         if self.primitive:
-            prim_slab = struct.get_primitive_structure(tolerance=tol, reduce=False)
-
-            if energy is not None:
-                energy *= prim_slab.volume / struct.volume
+            prim_slab = struct.get_primitive_structure(tolerance=tol, reduce=self.allow_smaller_than_ouc)
 
             # Find a reduced OUC
             prim_slab_l = prim_slab.lattice
-            prim_ouc = ouc.get_primitive_structure(
-                constrain_latt={
+            prim_ouc = self.oriented_unit_cell.get_primitive_structure(
+                constrain_latt={}
+                if self.allow_smaller_than_ouc
+                else {
                     "a": prim_slab_l.a,
                     "b": prim_slab_l.b,
                     "alpha": prim_slab_l.alpha,
                     "beta": prim_slab_l.beta,
                     "gamma": prim_slab_l.gamma,
                 },
-                reduce=False,
+                reduce=self.allow_smaller_than_ouc,
             )
 
-            # Ensure lattice a and b are consistent between the OUC and the slab
-            a_b_consistent = np.isclose(prim_slab_l.a, prim_ouc.lattice.a) and np.isclose(
-                prim_slab_l.b, prim_ouc.lattice.b
-            )
-            if a_b_consistent:
+            # Ensure lattice a and b is consistent between the OUC and the slab
+            if self.allow_smaller_than_ouc or (
+                np.isclose(prim_slab_l.a, prim_ouc.lattice.a) and np.isclose(prim_slab_l.b, prim_ouc.lattice.b)
+            ):
+                if energy is not None:
+                    energy *= prim_slab.volume / struct.volume
                 struct = prim_slab
                 ouc = prim_ouc
+
+        # Correct the scale_factor for LLL, primitivization, c-axis changes
+        # Orienting of either lattice must happen after this, not before
+        scale_factor = np.linalg.solve(
+            self.parent.lattice.matrix.T,
+            struct.lattice.matrix.T,
+        ).T
 
         return Slab(
             struct.lattice,
@@ -1220,7 +1231,7 @@ class SlabGenerator:
 
     def get_slabs(
         self,
-        bonds: dict[tuple[Species | Element, Species | Element], float] | None = None,
+        bonds: dict[tuple[Species | Element | str, Species | Element | str], float] | None = None,
         ftol: float = 0.1,
         tol: float = 0.1,
         max_broken_bonds: int = 0,
@@ -1276,8 +1287,8 @@ class SlabGenerator:
 
             # Compute a Cartesian z-coordinate distance matrix
             # TODO (@DanielYang59): account for periodic boundary condition
-            dist_matrix: NDArray = np.zeros((n_atoms, n_atoms))
-            for i, j in itertools.combinations(list(range(n_atoms)), 2):
+            dist_matrix: NDArray = np.zeros((n_atoms, n_atoms), dtype=np.float64)
+            for i, j in itertools.combinations(range(n_atoms), 2):
                 if i != j:
                     z_dist = frac_coords[i][2] - frac_coords[j][2]
                     z_dist = abs(z_dist - round(z_dist)) * self._proj_height
@@ -1311,7 +1322,7 @@ class SlabGenerator:
             return sorted(terminations)
 
         def get_z_ranges(
-            bonds: dict[tuple[Species | Element, Species | Element], float],
+            bonds: dict[tuple[Species | Element | str, Species | Element | str], float],
             ztol: float,
         ) -> list[tuple[float, float]]:
             """Collect occupied z ranges where each range is a (lower_z, upper_z) tuple.
@@ -1354,7 +1365,7 @@ class SlabGenerator:
         # Get occupied z_ranges
         z_ranges = [] if bonds is None else get_z_ranges(bonds, ztol)
 
-        slabs = []
+        slabs: list[Slab] = []
         for termination in gen_possible_terminations(ftol=ftol):
             # Calculate total number of bonds broken (how often the
             # termination fall within the z_range occupied by a bond)
@@ -1397,12 +1408,12 @@ class SlabGenerator:
         else:
             final_slabs = slabs
 
-        return cast("list[Slab]", sorted(final_slabs, key=lambda slab: slab.energy))
+        return sorted(final_slabs, key=lambda slab: slab.energy or 0)
 
     def repair_broken_bonds(
         self,
         slab: Slab,
-        bonds: dict[tuple[Species | Element, Species | Element], float],
+        bonds: dict[tuple[Species | Element | str, Species | Element | str], float],
     ) -> Slab:
         """Repair broken bonds (specified by the bonds parameter) due to
         slab cleaving, and repair them by moving undercoordinated atoms
@@ -1610,6 +1621,7 @@ def generate_all_slabs(
     repair: bool = False,
     include_reconstructions: bool = False,
     in_unit_planes: bool = False,
+    allow_smaller_than_ouc: bool = False,
 ) -> list[Slab]:
     """Find all unique Slabs up to a given Miller index.
 
@@ -1670,6 +1682,12 @@ def generate_all_slabs(
             Fe(100) will have more layers. The slab thickness
             will be in min_slab_size/math.ceil(self._proj_height/dhkl)
             multiples of oriented unit cells.
+        allow_smaller_than_ouc (bool = False): Allow slabs that are smaller
+            than the OUC via primitivization? Enables reduction of the OUC and Slab,
+            and also allows the lattice of the slab to diverge from the lattice of the OUC.
+            This is relevant with primitivization, as the used algorithm may only
+            find a different surface cell if the termination is better than in the
+            OUC.
     """
     all_slabs: list[Slab] = []
 
@@ -1684,6 +1702,7 @@ def generate_all_slabs(
             primitive=primitive,
             max_normal_search=max_normal_search,
             in_unit_planes=in_unit_planes,
+            allow_smaller_than_ouc=allow_smaller_than_ouc,
         )
         slabs = gen.get_slabs(
             bonds=bonds,
@@ -2008,8 +2027,7 @@ def get_symmetrically_equivalent_miller_indices(
         _miller_index = (miller_index[0], miller_index[1], miller_index[2])
 
     max_idx = max(np.abs(miller_index))
-    idx_range = list(range(-max_idx, max_idx + 1))
-    idx_range.reverse()
+    idx_range = range(max_idx, -max_idx - 1, -1)
 
     # Skip crystal system analysis if already given
     if system:
@@ -2029,13 +2047,14 @@ def get_symmetrically_equivalent_miller_indices(
         symm_ops = structure.lattice.get_recp_symmetry_operation()
 
     equivalent_millers: list[tuple[int, int, int]] = [_miller_index]  # type: ignore[list-item]
+    # Explicit x3 repeat instead of keyword, so mypy understands it correctly
     for miller in itertools.product(idx_range, idx_range, idx_range):
         if miller == _miller_index:
             continue
 
         if any(idx != 0 for idx in miller):
             if _is_in_miller_family(miller, equivalent_millers, symm_ops):
-                equivalent_millers += [miller]
+                equivalent_millers.append(miller)
 
             # Include larger Miller indices in the family of planes
             if (

--- a/tests/core/test_surface.py
+++ b/tests/core/test_surface.py
@@ -896,6 +896,68 @@ class TestMillerIndexFinder(MatSciTest):
         # termination for each distinct Miller _index
         assert len(miller_list) == len(all_miller_list)
 
+    def test_computed_scale_factor(self):
+        """Test that the scale factor of a Slab matches the lattice transformation."""
+        # With no reorientation, it should be the exact transformation
+        struct_lattice = Lattice.hexagonal(5, 17)
+        # Approximately calcite (spacegroup R-3c)
+        struct = Structure.from_spacegroup(
+            167, struct_lattice, ("Ca", "C", "O"), ((0, 0, 0), (0, 0, 0.25), (0.25, 0, 0.25))
+        )
+
+        # Basic SlabGenerator
+        slabgen = SlabGenerator(struct, (1, 0, 4), 1, 1, in_unit_planes=True, primitive=False, reorient_lattice=False)
+        # Should work with and without bonds and with all settings
+        for slab in slabgen.get_slabs(bonds={("C", "O"): 3}):
+            # Slab matrix should result from scale_factor and source lattice
+            computed_matrix = slab.scale_factor @ struct_lattice.matrix
+            assert np.allclose(slab.lattice.matrix, computed_matrix)
+            # Also holds for the OUC, as long as primitivization is disabled
+            # Note that the OUC is shorter in c (only slab-part, no vacuum)
+            computed_matrix[2] /= 2
+            assert np.allclose(slab.oriented_unit_cell.lattice.matrix, computed_matrix)
+        # Enable settings that modify the matrices
+        slabgen.primitive = True
+        slabgen.reorient_lattice = True
+        slabgen.lll_reduce = True
+        for slab in slabgen.get_slabs():
+            # slab matrix is rotated - only determinant will be correct
+            assert np.isclose(np.linalg.det(slab.scale_factor), slab.lattice.volume / struct.lattice.volume)
+
+    def test_smaller_than_ouc_slab(self):
+        """Test for potential Slabs smaller than the OUC."""
+        # Approximately calcite (spacegroup R-3c)
+        struct = Structure.from_spacegroup(
+            167, Lattice.hexagonal(5, 17), ("Ca", "C", "O"), ((0, 0, 0), (0, 0, 0.25), (0.25, 0, 0.25))
+        )
+        # Most stable surface is (104) - represented as [42-1] x [010] (or equivalent directions)
+        slabgen = SlabGenerator(struct, (1, 0, 4), 1, 1, in_unit_planes=True, primitive=False)
+
+        # Non-primitive Slab will be [010] x [-401] (essentially integer scale factor)
+        # Note the long b-side and the 67.6° gamma angle
+        # c is [002] because it includes the vacuum
+        np_slab = slabgen.get_slab(0.125)
+        assert np.allclose(np_slab.scale_factor, [[0, 1, 0], [-4, 0, 1], [0, 0, 2]])
+        # Check expected lattice params a/b/gamma as well for safety
+        expected = (5.0, 26.248809496813376, 67.60624150257428)
+        lat = np_slab.lattice
+        assert np.allclose((lat.a, lat.b, lat.gamma), expected)
+
+        # We actually want [010] x [42-1], which have a 90° gamma angle:
+        # Due to the rhombohedral centering, the [42-1] vector can be shortened to a third of the full [42-1]
+        # The primitive slab will diverge in the slab and OUC lattice because .get_primitive_structure struggles
+        # with this primitivization (requires a "good" shift like 0.125, not a "bad" one like 0)
+        # Thus allow_smaller_than_ouc must be enabled
+        slabgen.primitive = True
+        slabgen.allow_smaller_than_ouc = True
+        p_slab = slabgen.get_slab(0.125)
+        # We get [010] x [-4-21]/3 from this configuration (note that c also changes to be nearly orthogonal)
+        assert np.allclose(p_slab.scale_factor, [[0, 1, 0], [-4 / 3, -2 / 3, 1 / 3], [4, 2, 1]])
+        # Check expected lattice params a/b/gamma again
+        expected = (5.0, 8.08977406634106, 90.0)
+        lat = p_slab.lattice
+        assert np.allclose((lat.a, lat.b, lat.gamma), expected)
+
     def test_miller_index_from_sites(self):
         """Test surface miller index convenience function."""
         # test on a cubic system


### PR DESCRIPTION
Introduces two key changes (and one smaller group of changes, explanation below):
1. New `allow_smaller_than_ouc` keyword for `SlabGenerator`: Disables lattice constraint and enables structure reduction for slab and OUC primitivization (effectively an enhanced reversion of #24 as an option).
2. The `scale_factor` of slabs is now recalculated based on the slab itself, not the scale factor generated from the miller index. **This changes the returned scale factor**: It is now slightly off-integer in most cases, c is now the entire slab c (not just the non-vacuum part - I am open to changing this back) and with primitivization the scale factor can now be non-integer.
3. Some small bugs, typing and performance cases were improved. E. g. if the primitivization is rejected, the energy remains unchanged; the OUC keeps its type; less structures etc. are copied since pymatgen generally trusts the user to not unknowingly modify the data in many other cases.

## Explanation

Starting with #24, the size of the surface of Slabs from a `SlabGenerator` was locked to the size of their non-reduced OUC.
This may be the expected behaviour in some use cases, but it blocks primitivizations which `Structure.get_primitive_structure` is only able to find for selected terminations, if the primitivization is not found for the OUC termination (and with `reduce=False` proper removal of centering is blocked).
One such example is the (104) surface of calcite (space group R-3c): Without primitivization, pymatgen generates the [010] x [-401] surface (which is fine, but very large). The common side vectors you will find in the literature are [42-1] x [010] (or equivalents), with [42-1] being reduced to a third of the full vector due to the centering (I will now call this [42-1]/3). This is the preferred surface representation because it is both smaller and orthagonal (gamma 90°, approx. 35 Å² surface area).
But with primitivization, pymatgen currently creates a [81-2]/3 x [-401] (15.6 Å x 24.2 Å, gamma 174.7°) slab with that same surface area, because `struct.get_primitive_structure(tolerance=tol, reduce=False)` returns that surface.
The new `allow_smaller_than_ouc` setting for the `SlabGenerator` (and for `get_all_slabs`) enables reduction of the primitive slab and primitive OUC (like before #24), but it also completely removes the lattice constraints on the primitive OUC and the following check that the OUC and slab have similar `a` and `b` (note that `gamma` was and still is missing from this surface equivalence check, but at least one test is based on gamma changing and I did not change this behaviour).
This way, `Structure.get_primitive_structure` fails at finding the [42-1]/3 x [010] for the OUC, but it manages to find [-4-21]/3 x [010] for a termination from `gen_possible_terminations` such as 0.125.

This is similar to before #24, as pymatgen used to find the [-4-21]/3 x [010], as the behaviour always followed the current `reduce=True`.

I also changed the `scale_factor` for the following reason: For a non-primitive slab, the [uvw] directions of the slab vectors were always available in the `Slab.scale_factor` ([0] for `a` and so on), with the matrix being `slab_lattice_matrix = slab.scale_factor @ structure.lattice.matrix` (correct for a and b; c only if no vacuum was used). The moment `primitive=True` is enabled, this is not guaranteed to be true anymore, even though there is no indication for this behaviour difference. The returned vectors remained the non-primitive vectors. The same holds for LLL reduction.
I changed this such that `slab_lattice_matrix = slab.scale_factor @ structure.lattice.matrix` always holds. This means that the scale factor changes, as stated above. In the primitive case, the side vectors stated by the scale factor now actually correspond to the side vectors of the slab. This does also change the c vector to be larger if vacuum is used and due to floating-point inaccuracy it causes all values to be slightly off-integer even for a non-primitive case. (This can be fixed by rounding if all values are nearly integer, if necessary.)


## Checklist

- [x] Google format doc strings added. Check with `ruff`.
- [x] Type annotations included. Check with `mypy`.
- [x] Tests added for new features/fixes.