### PR TITLE
`__getitem__` typing for `SiteCollection` and subclasses (e. g. `Structure`)

### DIFF
--- a/src/pymatgen/core/local_env.py
+++ b/src/pymatgen/core/local_env.py
@@ -223,8 +223,7 @@ def _handle_disorder(structure: Structure, on_disorder: on_disorder_options):
     # As a workaround, we create a new structure with majority species on each site.
     structure = structure.copy()  # make a copy so we don't mutate the original structure
     for idx, site in enumerate(structure):
-        max_specie = max(site.species, key=site.species.get)
-        max_val = site.species[max_specie]
+        max_specie, max_val = max(site.species.items(), key=lambda item: item[1])
         if max_val <= 0.5:
             if on_disorder == "take_majority_strict":
                 raise ValueError(

--- a/src/pymatgen/core/structure.py
+++ b/src/pymatgen/core/structure.py
@@ -1192,7 +1192,7 @@ class IStructure(SiteCollection[PeriodicSite], MSONable):
                 )
                 new_sites.append(periodic_site)
 
-        new_charge = self._charge * np.linalg.det(scale_matrix) if self._charge else None
+        new_charge = self._charge * np.linalg.det(scale_matrix) if self._charge is not None else None
         return Structure.from_sites(new_sites, charge=new_charge, to_unit_cell=True).relabel_sites(ignore_uniq=True)
 
     def __rmul__(self, scaling_matrix):

--- a/src/pymatgen/core/structure.py
+++ b/src/pymatgen/core/structure.py
@@ -19,7 +19,21 @@ import sys
 import warnings
 from abc import ABC, abstractmethod
 from collections import defaultdict
-from typing import TYPE_CHECKING, Literal, cast, get_args, overload
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    ClassVar,
+    Generic,
+    Literal,
+    Self,
+    SupportsIndex,
+    TypeAlias,
+    TypeVar,
+    cast,
+    get_args,
+    overload,
+    override,
+)
 
 import numpy as np
 import orjson
@@ -49,7 +63,6 @@ from pymatgen.util.due import Doi, due
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable, Iterator, Sequence
-    from typing import Any, ClassVar, Self, SupportsIndex, TypeAlias
 
     import moyopy
     import pandas as pd
@@ -63,6 +76,8 @@ if TYPE_CHECKING:
 
     from pymatgen.symmetry.maggroups import MagneticSpaceGroup
     from pymatgen.util.typing import CompositionLike, PathLike, SpeciesLike
+
+SiteType = TypeVar("SiteType", bound=Site)
 
 FileFormats: TypeAlias = Literal[
     "cif",
@@ -212,7 +227,7 @@ class PeriodicNeighbor(PeriodicSite):
         return cast("Self", super(Site, cls).from_dict(dct))
 
 
-class SiteCollection(collections.abc.Sequence, ABC):
+class SiteCollection(collections.abc.Sequence[SiteType], ABC, Generic[SiteType]):
     """Basic SiteCollection. Essentially a sequence of Sites or PeriodicSites.
     This serves as a base class for Molecule (a collection of Site, i.e., no
     periodicity) and Structure (a collection of PeriodicSites, i.e.,
@@ -229,12 +244,15 @@ class SiteCollection(collections.abc.Sequence, ABC):
     def __contains__(self, site: object) -> bool:
         return site in self.sites
 
-    def __iter__(self) -> Iterator[PeriodicSite]:
+    def __iter__(self) -> Iterator[SiteType]:
         return iter(self.sites)
 
-    # TODO return type needs fixing (can be Sequence[PeriodicSite] but raises lots of mypy errors)
-    def __getitem__(self, ind: int | slice):
-        return self.sites[ind]  # type: ignore[return-value]
+    @overload
+    def __getitem__(self, ind: int) -> SiteType: ...
+    @overload
+    def __getitem__(self, ind: slice) -> Sequence[SiteType]: ...
+    def __getitem__(self, ind: int | slice) -> SiteType | Sequence[SiteType]:
+        return self.sites[ind]
 
     def __len__(self) -> int:
         return len(self.sites)
@@ -244,16 +262,16 @@ class SiteCollection(collections.abc.Sequence, ABC):
         return hash(self.composition)
 
     @property
-    def sites(self) -> list[PeriodicSite] | tuple[PeriodicSite, ...]:
+    def sites(self) -> Sequence[SiteType]:
         """The sites in the Structure."""
         return self._sites
 
     @sites.setter
-    def sites(self, sites: Sequence[PeriodicSite]) -> None:
+    def sites(self, sites: Sequence[SiteType]) -> None:
         """Set the sites in the Structure."""
         # If self is mutable Structure or Molecule, set _sites as list
         is_mutable = isinstance(self._sites, collections.abc.MutableSequence)
-        self._sites: list[PeriodicSite] | tuple[PeriodicSite, ...] = list(sites) if is_mutable else tuple(sites)
+        self._sites: Sequence[SiteType] = list(sites) if is_mutable else tuple(sites)
 
     @abstractmethod
     def copy(self) -> Self:
@@ -324,7 +342,7 @@ class SiteCollection(collections.abc.Sequence, ABC):
         """Specie -> Species rename, to maintain backwards compatibility."""
         return self.types_of_species
 
-    def group_by_types(self) -> Iterator[Site | PeriodicSite]:
+    def group_by_types(self) -> Iterator[SiteType]:
         """Iterate over species grouped by type."""
         for sp_typ in self.types_of_species:
             for site in self:
@@ -754,11 +772,11 @@ class SiteCollection(collections.abc.Sequence, ABC):
 
         return self
 
-    def extract_cluster(self, target_sites: list[Site], **kwargs) -> list[Site]:
+    def extract_cluster(self, target_sites: Iterable[SiteType], **kwargs) -> list[SiteType]:
         """Extract a cluster of atoms based on bond lengths.
 
         Args:
-            target_sites (list[Site]): Initial sites from which to nucleate cluster.
+            target_sites (Iterable[Site]): Initial sites from which to nucleate cluster.
             **kwargs: kwargs passed through to CovalentBond.is_bonded.
 
         Returns:
@@ -1005,7 +1023,7 @@ class SiteCollection(collections.abc.Sequence, ABC):
         return AseAtomsAdaptor.get_structure(atoms, cls=cls, **kwargs)  # type:ignore[type-var,return-value]
 
 
-class IStructure(SiteCollection, MSONable):
+class IStructure(SiteCollection[PeriodicSite], MSONable):
     """Basic immutable Structure object with periodicity. Essentially a sequence
     of PeriodicSites having a common lattice. IStructure is made to be
     (somewhat) immutable so that they can function as keys in a dict. To make
@@ -3237,7 +3255,7 @@ class IStructure(SiteCollection, MSONable):
         return dictdata
 
 
-class IMolecule(SiteCollection, MSONable):
+class IMolecule(SiteCollection[Site], MSONable):
     """Basic immutable Molecule object without periodicity. Essentially a
     sequence of sites. IMolecule is made to be immutable so that they can
     function as keys in a dict. For a mutable object, use the Molecule class.
@@ -3304,7 +3322,7 @@ class IMolecule(SiteCollection, MSONable):
             label = labels[idx] if labels else None
             sites.append(Site(species[idx], coords[idx], properties=prop, label=label))  # type:ignore[index]
 
-        self._sites = tuple(sites)  # type:ignore[arg-type]
+        self._sites: tuple[Site, ...] = tuple(sites)  # type:ignore[arg-type]
         if validate_proximity and not self.is_valid():
             raise StructureError("Molecule contains sites that are less than 0.01 Angstrom apart!")
 
@@ -3881,7 +3899,7 @@ class IMolecule(SiteCollection, MSONable):
         return new
 
 
-class Structure(IStructure, collections.abc.MutableSequence):
+class Structure(IStructure, collections.abc.MutableSequence[PeriodicSite]):
     """Mutable version of structure."""
 
     __hash__ = None  # type: ignore[assignment]
@@ -3953,6 +3971,22 @@ class Structure(IStructure, collections.abc.MutableSequence):
         )
 
         self._sites: list[PeriodicSite] = list(self._sites)  # type: ignore[assignment]
+
+    @SiteCollection.sites.getter
+    def sites(self) -> list[PeriodicSite]:
+        """The mutable sites in the Structure."""
+        return self._sites
+
+    # Explicit typing: _sites is a list[PeriodicSite], so this return is guaranteed
+    @overload
+    def __getitem__(self, ind: int) -> PeriodicSite: ...
+
+    @overload
+    def __getitem__(self, ind: slice) -> list[PeriodicSite]: ...
+
+    @override
+    def __getitem__(self, ind: int | slice) -> PeriodicSite | list[PeriodicSite]:
+        return self._sites[ind]
 
     def __setitem__(
         self,
@@ -4810,7 +4844,7 @@ class Structure(IStructure, collections.abc.MutableSequence):
         raise ValueError(f"Unsupported {prototype=}!")
 
 
-class Molecule(IMolecule, collections.abc.MutableSequence):
+class Molecule(IMolecule, collections.abc.MutableSequence[Site]):
     """Mutable Molecule. It has all the methods in IMolecule,
     and allows a user to perform edits on the molecule.
     """
@@ -4836,7 +4870,7 @@ class Molecule(IMolecule, collections.abc.MutableSequence):
                 list of dict of elements/species and occupancies, a List of
                 elements/specie specified as actual Element/Species, Strings
                 ("Fe", "Fe2+") or atomic numbers (1,56).
-            coords (3x1 array): list of Cartesian coordinates of each species.
+            coords (Nx3 array): list of Cartesian coordinates of each species.
             charge (float): Charge for the molecule. Defaults to 0.
             spin_multiplicity (int): Spin multiplicity for molecule.
                 Defaults to None, which means that the spin multiplicity is
@@ -4870,6 +4904,22 @@ class Molecule(IMolecule, collections.abc.MutableSequence):
             properties=properties,
         )
         self._sites: list[Site] = list(self._sites)  # type:ignore[assignment]
+
+    @SiteCollection.sites.getter
+    def sites(self) -> list[Site]:
+        """The mutable sites in this Molecule."""
+        return self._sites
+
+    # Explicit typing: _sites is a list[Site], so this return is guaranteed
+    @overload
+    def __getitem__(self, ind: int) -> Site: ...
+
+    @overload
+    def __getitem__(self, ind: slice) -> list[Site]: ...
+
+    @override
+    def __getitem__(self, ind: int | slice) -> Site | list[Site]:
+        return self._sites[ind]
 
     def __setitem__(
         self,

--- a/src/pymatgen/core/structure.py
+++ b/src/pymatgen/core/structure.py
@@ -1790,7 +1790,7 @@ class IStructure(SiteCollection[PeriodicSite], MSONable):
             include_index=True,
             include_image=True,
             sites=sites,
-            numerical_tol=1e-8,
+            numerical_tol=numerical_tol,
         )
         center_indices: list[int] = []
         points_indices: list[int] = []

--- a/src/pymatgen/core/structure.py
+++ b/src/pymatgen/core/structure.py
@@ -32,7 +32,6 @@ from typing import (
     cast,
     get_args,
     overload,
-    override,
 )
 
 import numpy as np
@@ -60,6 +59,11 @@ from pymatgen.core.units import Length, Mass
 # + symmetry.groups (~6-10 ms) on every `from pymatgen.core import Structure`.
 from pymatgen.util.coord import all_distances, get_angle, lattice_points_in_supercell
 from pymatgen.util.due import Doi, due
+
+try:
+    from typing import override  # Python 3.12+
+except ImportError:
+    from typing_extensions import override  # Python 3.11
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable, Iterator, Sequence

--- a/src/pymatgen/core/surface.py
+++ b/src/pymatgen/core/surface.py
@@ -60,7 +60,7 @@ logger = logging.getLogger(__name__)
 
 
 class Slab(Structure):
-    """Hold information for a Slab, with additional
+    """Holds information for a Slab, with additional
     attributes pertaining to slabs, but the init method does not
     actually create a slab. Also has additional methods that returns other information
     about a Slab such as the surface area, normal, and atom adsorption.
@@ -92,10 +92,7 @@ class Slab(Structure):
         and methods pertaining to Slabs.
 
         Args:
-            lattice (Lattice/3x3 array): The lattice, either as a
-                pymatgen.core.Lattice or simply as any 2D array.
-                Each row should correspond to a lattice
-                vector. e.g. [[10,0,0], [20,10,0], [0,0,30]].
+            lattice (Lattice): The lattice as a pymatgen.core.Lattice.
             species ([Species]): Sequence of species on each site. Can take in
                 flexible input, including:
 
@@ -106,7 +103,7 @@ class Slab(Structure):
                 ii. List of dict of elements/species and occupancies, e.g.
                     [{"Fe": 0.5, "Mn": 0.5}, ...]. This allows the setup of
                     disordered structures.
-            coords (Nx3 array): list of fractional/cartesian coordinates of each species.
+            coords (Nx3 array): Array of fractional/cartesian coordinates of each species.
             miller_index (tuple[int, ...]): Miller index of plane parallel to
                 surface. Note that this is referenced to the input structure. If
                 you need this to be based on the conventional cell,
@@ -115,7 +112,7 @@ class Slab(Structure):
                 this Slab is created (by scaling in the c-direction).
             shift (float): The NEGATIVE of shift in the c-direction applied
                 to get the termination.
-            scale_factor (np.ndarray): scale_factor Final computed scale factor
+            scale_factor (np.ndarray): Final computed scale factor
                 that brings the parent cell to the surface cell.
             reorient_lattice (bool): reorients the lattice parameters such that
                 the c direction is along the z axis.
@@ -260,7 +257,9 @@ class Slab(Structure):
             shift=dct["shift"],
             scale_factor=np.array(dct["scale_factor"]),
             site_properties=struct.site_properties,
+            reconstruction=dct.get("reconstruction"),
             energy=dct["energy"],
+            reorient_lattice=dct.get("reorient_lattice", True),
         )
 
     def as_dict(self, **kwargs) -> dict:
@@ -274,6 +273,7 @@ class Slab(Structure):
         dct["scale_factor"] = self.scale_factor.tolist()  # np.ndarray is not JSON serializable
         dct["reconstruction"] = self.reconstruction
         dct["energy"] = self.energy
+        dct["reorient_lattice"] = self.reorient_lattice
         return dct
 
     def copy(self, site_properties: dict[str, Any] | None = None) -> Self:
@@ -301,6 +301,8 @@ class Slab(Structure):
             self.scale_factor,
             site_properties=props,
             reorient_lattice=self.reorient_lattice,
+            reconstruction=self.reconstruction,
+            energy=self.energy,
         )
 
     def is_symmetric(self, symprec: float = 0.1) -> bool:
@@ -494,6 +496,7 @@ class Slab(Structure):
             energy=self.energy,
             reorient_lattice=self.reorient_lattice,
             site_properties=self.site_properties,
+            reconstruction=self.reconstruction,
         )
 
     def get_tasker2_slabs(
@@ -594,6 +597,7 @@ class Slab(Structure):
                     self.scale_factor,
                     energy=self.energy,
                     reorient_lattice=self.reorient_lattice,
+                    reconstruction=self.reconstruction,
                 )
                 slabs.append(slab)
         stm = StructureMatcher()
@@ -624,6 +628,7 @@ class Slab(Structure):
             self.scale_factor,
             site_properties=struct.site_properties,
             reorient_lattice=self.reorient_lattice,
+            reconstruction=self.reconstruction,
         )
 
     def add_adsorbate_atom(


### PR DESCRIPTION
This PR adds a few small fixes, of which the two noteworthy ones are the following:
1. `SiteCollection.__getitem__` now has typing via a `TypeVar`, which `(I)Structure`s set to `PeriodicSite` and `Molecule`s set to `Site`. Thus, Molecules now correctly type that they use `Site` and note `PeriodicSite`. The immutable types now return their SiteType or a `Sequence` of their site type (see a)), while the mutable types return an explicit `list` instead of the `Sequence`.
2. `Slab`s now preserve the reconstruction and reorient_lattice properties through copies and similar functions. One case where this matters is if an (intentionally) non-reoriented Slab is dumped and then reloaded, currently it will be forcibly reoriented.

a) This typing should be mostly transparent to users, perhaps with some typechecker warnings as pymatgen is now explicit about what the returns are. I believe it is not possible to more strictly type the immutable collections (which return a tuple as a sequence), as they are superclasses of the mutable versions. Also, I think the single item overload override (in `Structure`/`Molecule`) is not necessary, but it should reduce the confusion of what actually happens with the types.