### PR TITLE
Improve R-centering in `get_conventional_to_primitive_transformation_matrix` and `get_primitive_standard_structure`

### DIFF
--- a/src/pymatgen/symmetry/analyzer.py
+++ b/src/pymatgen/symmetry/analyzer.py
@@ -549,20 +549,25 @@ class SpacegroupAnalyzer:
         if space_group.startswith("P"):
             return np.eye(3, dtype=np.float64)
 
+        # Hexagonal to rhombohedral - for S/C orientation see get_primitive_standard_structure
         if space_group.startswith("R"):
             return np.array([[-1, 1, 1], [2, 1, 1], [-1, -2, 1]], dtype=np.float64) / 3
 
+        # Setyawan/Curtarolo A.3/A.5/A.8
         if space_group.startswith("I"):
             return np.array([[-1, 1, 1], [1, -1, 1], [1, 1, -1]], dtype=np.float64) / 2
 
+        # S/C A.2/A.7
         if space_group.startswith("F"):
             return np.array([[0, 1, 1], [1, 0, 1], [1, 1, 0]], dtype=np.float64) / 2
 
         # Convert face-centered cell. Note that this converts a C-centered cell,
         # A-centered cells must be standardized to them beforehand.
         if space_group.startswith(("C", "A")):
+            # S/C A.13
             if self.get_crystal_system() == "monoclinic":
                 return np.array([[1, 1, 0], [-1, 1, 0], [0, 0, 2]], dtype=np.float64) / 2
+            # S/C A.2/A.9
             return np.array([[1, -1, 0], [1, 1, 0], [0, 0, 2]], dtype=np.float64) / 2
 
         raise ValueError(f"Unrecognized space group {space_group}.")
@@ -622,7 +627,7 @@ class SpacegroupAnalyzer:
                 new_sites.append(new_s)
 
         # Reorient rhombohedral lattices (keep sites & frac. coordinates)
-        # (to match Setyawan/Curtarolo convention)
+        # (to match Setyawan/Curtarolo convention in A.11)
         if sg_symbol.startswith("R"):
             a = prim_lattice.a
             alpha = math.radians(prim_lattice.alpha)

--- a/src/pymatgen/symmetry/analyzer.py
+++ b/src/pymatgen/symmetry/analyzer.py
@@ -525,7 +525,7 @@ class SpacegroupAnalyzer:
     @cite_conventional_cell_algo
     def get_conventional_to_primitive_transformation_matrix(
         self,
-        international_monoclinic: bool = True,
+        international_monoclinic: bool | None = None,
     ) -> NDArray:
         """Get the transformation matrix to transform a conventional unit cell to a
         primitive cell according to certain standards. The standards are defined in
@@ -534,8 +534,7 @@ class SpacegroupAnalyzer:
         299-312. doi:10.1016/j.commatsci.2010.05.010.
 
         Args:
-            international_monoclinic (bool): Whether to convert to proper international convention
-                such that beta is the non-right angle. Unused.
+            international_monoclinic (bool): Deprecated.
 
         Returns:
             Transformation matrix to go from conventional to primitive cell.
@@ -545,6 +544,15 @@ class SpacegroupAnalyzer:
             is expected. Therefore, the transformation matrix C->P is returned.
             All matrices have a positive determinant and therefore have no reflection component.
         """
+        # TODO: Remove deprecated keyword once enough time passed
+        # Unused since 2026.7.16, deprecated after 2026.7.27
+        if international_monoclinic is not None:
+            warnings.warn(
+                "international_monoclinic has no effect, is deprecated and will be removed in a future version.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
         space_group = self.get_space_group_symbol()
 
         if space_group.startswith("P"):

--- a/src/pymatgen/symmetry/analyzer.py
+++ b/src/pymatgen/symmetry/analyzer.py
@@ -598,7 +598,8 @@ class SpacegroupAnalyzer:
             keep_site_properties=keep_site_properties,
         )
 
-        if self.get_space_group_symbol().startswith("P"):
+        sg_symbol = self.get_space_group_symbol()
+        if sg_symbol.startswith("P"):
             return conv
 
         transf = self.get_conventional_to_primitive_transformation_matrix(
@@ -606,44 +607,42 @@ class SpacegroupAnalyzer:
         )
 
         new_sites: list[PeriodicSite] = []
-        lattice = Lattice(transf @ conv.lattice.matrix)
+        prim_lattice = Lattice(transf @ conv.lattice.matrix)
         for site in conv:
             new_s = PeriodicSite(
                 site.species,
                 site.coords,
-                lattice,
+                prim_lattice,
                 to_unit_cell=True,
                 coords_are_cartesian=True,
                 properties=site.properties,
             )
+            # Remove duplicate sites
             if not any(map(new_s.is_periodic_image, new_sites)):
                 new_sites.append(new_s)
 
-        if self.get_lattice_type() == "rhombohedral":
-            a = lattice.a
-            alpha = math.radians(lattice.alpha)
-            new_matrix = [
-                [a * cos(alpha / 2), -a * sin(alpha / 2), 0],
-                [a * cos(alpha / 2), a * sin(alpha / 2), 0],
-                [
-                    a * cos(alpha) / cos(alpha / 2),
-                    0,
-                    a * math.sqrt(1 - (cos(alpha) ** 2 / (cos(alpha / 2) ** 2))),
-                ],
-            ]
-            rhomb_sites = []
-            lattice = Lattice(new_matrix)
+        # Reorient rhombohedral lattices (keep sites & frac. coordinates)
+        # (to match Setyawan/Curtarolo convention)
+        if sg_symbol.startswith("R"):
+            a = prim_lattice.a
+            alpha = math.radians(prim_lattice.alpha)
+            cos_alpha = math.cos(alpha)
+            cos_alpha_h = math.cos(alpha / 2)
+            cos_fraction = cos_alpha / cos_alpha_h
+            a_sin_alpha_h = a * math.sin(alpha / 2)
+            new_matrix = (
+                (a * cos_alpha_h, -a_sin_alpha_h, 0.0),
+                (a * cos_alpha_h, a_sin_alpha_h, 0.0),
+                (
+                    a * cos_fraction,
+                    0.0,
+                    a * math.sqrt(1 - cos_fraction * cos_fraction),
+                ),
+            )
+            prim_lattice = Lattice(new_matrix)
+            # Edit the lattice in-place (sites are created above)
             for site in new_sites:
-                new_s = PeriodicSite(
-                    site.species,
-                    site.frac_coords,
-                    lattice,
-                    to_unit_cell=True,
-                    properties=site.properties,
-                )
-                if not any(map(new_s.is_periodic_image, new_sites)):
-                    rhomb_sites.append(new_s)
-            new_sites = rhomb_sites
+                site.lattice = prim_lattice
 
         return Structure.from_sites(new_sites)
 

--- a/src/pymatgen/symmetry/analyzer.py
+++ b/src/pymatgen/symmetry/analyzer.py
@@ -543,6 +543,7 @@ class SpacegroupAnalyzer:
         Notes:
             Note that for face-centered space groups (C-/A-centered), standardization to C-centering
             is expected. Therefore, the transformation matrix C->P is returned.
+            All matrices have a positive determinant and therefore have no reflection component.
         """
         space_group = self.get_space_group_symbol()
 
@@ -550,8 +551,9 @@ class SpacegroupAnalyzer:
             return np.eye(3, dtype=np.float64)
 
         # Hexagonal to rhombohedral - for S/C orientation see get_primitive_standard_structure
+        # Matches spglib (transposed for row lattice vectors)
         if space_group.startswith("R"):
-            return np.array([[-1, 1, 1], [2, 1, 1], [-1, -2, 1]], dtype=np.float64) / 3
+            return np.array([[2, 1, 1], [-1, 1, 1], [-1, -2, 1]], dtype=np.float64) / 3
 
         # Setyawan/Curtarolo A.3/A.5/A.8
         if space_group.startswith("I"):
@@ -607,9 +609,7 @@ class SpacegroupAnalyzer:
         if sg_symbol.startswith("P"):
             return conv
 
-        transf = self.get_conventional_to_primitive_transformation_matrix(
-            international_monoclinic=international_monoclinic
-        )
+        transf = self.get_conventional_to_primitive_transformation_matrix()
 
         new_sites: list[PeriodicSite] = []
         prim_lattice = Lattice(transf @ conv.lattice.matrix)
@@ -667,7 +667,7 @@ class SpacegroupAnalyzer:
 
         Args:
             international_monoclinic (bool): Whether to convert to proper international convention
-                such that beta is the non-right angle.
+                such that beta is the non-right angle. Otherwise it will be alpha.
             keep_site_properties (bool): Whether to keep the input site properties (including
                 magnetic moments) on the sites that are still present after the refinement. Note:
                 This is disabled by default because the magnetic moments are not always directly

--- a/tests/symmetry/test_analyzer.py
+++ b/tests/symmetry/test_analyzer.py
@@ -528,6 +528,124 @@ class TestSpacegroupAnalyzer(MatSciTest):
         # and a/b are approximately equal
         assert math.isclose(lattice.a, lattice.b)
 
+    def test_primitivization_matrices(self):
+        """Test that `get_conventional_to_primitive_transformation_matrix` returns expected matrices."""
+
+        # Tests all branches for the expected result
+        # Expected matrices have positive determinants and match transposed spglib
+        # (= Setyawan/Curtarolo for non-R)
+
+        cases = (
+            (
+                "P",
+                Structure.from_spacegroup(
+                    "P1",
+                    Lattice.from_parameters(2, 3, 5, 85, 95, 105),
+                    ["H", "He"],
+                    np.array([[0, 0, 0], [0.137, 0.251, 0.389]]),
+                ),
+                np.eye(3),
+            ),
+            (
+                "R",
+                Structure.from_spacegroup(
+                    "R-3c",
+                    Lattice.hexagonal(2, 3),
+                    ["H"],
+                    [[0, 0, 0]],
+                ),
+                np.array(
+                    [
+                        [2, 1, 1],
+                        [-1, 1, 1],
+                        [-1, -2, 1],
+                    ],
+                )
+                / 3,
+            ),
+            (
+                "I",
+                Structure.from_spacegroup(
+                    "Im-3m",
+                    Lattice.cubic(2),
+                    ["H"],
+                    [[0, 0, 0]],
+                ),
+                np.array(
+                    [
+                        [-1, 1, 1],
+                        [1, -1, 1],
+                        [1, 1, -1],
+                    ],
+                )
+                / 2,
+            ),
+            (
+                "F",
+                Structure.from_spacegroup(
+                    "Fm-3m",
+                    Lattice.cubic(3),
+                    ["H"],
+                    [[0, 0, 0]],
+                ),
+                np.array(
+                    [
+                        [0, 1, 1],
+                        [1, 0, 1],
+                        [1, 1, 0],
+                    ],
+                )
+                / 2,
+            ),
+            (
+                "C, monoclinic",
+                Structure.from_spacegroup(
+                    "C2/m",
+                    Lattice.monoclinic(2, 3, 5, 100),
+                    ["H"],
+                    [[0, 0, 0]],
+                ),
+                np.array(
+                    [
+                        [1, 1, 0],
+                        [-1, 1, 0],
+                        [0, 0, 2],
+                    ],
+                )
+                / 2,
+            ),
+            (
+                "C, non-monoclinic",
+                Structure.from_spacegroup(
+                    "Cmmm",
+                    Lattice.orthorhombic(2, 3, 5),
+                    ["H"],
+                    [[0, 0, 0]],
+                ),
+                np.array(
+                    [
+                        [1, -1, 0],
+                        [1, 1, 0],
+                        [0, 0, 2],
+                    ],
+                )
+                / 2,
+            ),
+        )
+
+        for case, structure, expected in cases:
+            sga = SpacegroupAnalyzer(structure)
+            # Check for accidental changes in centering
+            assert sga.get_space_group_symbol()[0] == case[0]
+
+            np.testing.assert_allclose(
+                expected,
+                sga.get_conventional_to_primitive_transformation_matrix(),
+                rtol=0,
+                atol=1e-14,
+                err_msg=f"Incorrect matrix for {case}.",
+            )
+
     def test_bad_structure(self):
         struct = Structure(Lattice.cubic(5), ["H", "H"], [[0.0, 0.0, 0.0], [0.001, 0.0, 0.0]])
 


### PR DESCRIPTION
With this PR, `get_conventional_to_primitive_transformation_matrix` and `get_primitive_standard_structure` are improved:
1. `get_conventional_to_primitive_transformation_matrix` now always returns a positive determinant matrix, meaning `trans_matrix @ lattice_matrix` now never reflects the lattice. This is only a change for `R`-centering, as all other matrices already followed this rule (see a)).
2. `get_primitive_standard_structure` now doesn't re-check if coordinates are periodic images of each other in rhombohedral cells after rotating the lattice, as a lattice rotation should never lead to that being the case. This (combined with in-place editing of the lattice of the new sites) also improves the performance of this branch.
3. `international_monoclinic` is now explicitly deprecated - I assume this is preferred to leaving an unused argument forever.
4. `get_conventional_to_primitive_transformation_matrix` now has tests for the exact expected matrices.

a) In the Setyawan/Curtarolo paper I can only find the transformations for the non-R cases (I have added them as comments). Those all match and have positive determinants. Only the R case had a negative determinant (ever since the matrix was added in https://github.com/materialsproject/pymatgen-core/commit/33d5fa3f27b4d6af0eddbe2d632736ca5123e419), which would affect chiral structures, as the resulting matrix from `trans_matrix @ lattice_matrix` would be left-handed. Note that `get_primitive_standard_structure` (until https://github.com/materialsproject/pymatgen-core/commit/b111eb42c432bf1c0483055a0300d0e5d4aaa0b4 and since #88) "fixed" this for achiral structures by recreating the lattice as a right-handed lattice. Therefore the actual impact is rather small, assuming `get_primitive_standard_structure` is used significantly more than `get_conventional_to_primitive_transformation_matrix`.
The new matrix switches the first and second row to have a +1/3 determinant instead of -1/3 and it matches [spglib](https://github.com/spglib/spglib/blob/a6b561fb60cdd021a1ac90852c3c2ae14405b2c8/src/spacegroup.c#L347-L349) (transposed):
```c
static double R_mat[3][3] = {{2. / 3, -1. / 3, -1. / 3},
                             {1. / 3, 1. / 3, -2. / 3},
                             {1. / 3, 1. / 3, 1. / 3}};
```

## Checklist

- [x] Google format doc strings added. Check with `ruff`.
- [x] Type annotations included. Check with `mypy`.
- [x] Tests added for new features/fixes.
