### PR TITLE
Make `SlabGenerator.gen_possible_terminations` a public function

### DIFF
--- a/src/pymatgen/core/surface.py
+++ b/src/pymatgen/core/surface.py
@@ -1236,6 +1236,61 @@ class SlabGenerator:
             energy=energy,
         )
 
+    def gen_possible_terminations(self, ftol: float) -> list[float]:
+        """Generate possible terminations by clustering z coordinates.
+
+        Args:
+            ftol (float): Threshold for fcluster to check if
+                two atoms are on the same plane.
+
+        Returns:
+            termination_shifts (list[float]): Shifts for terminations that
+        """
+        frac_coords = self.oriented_unit_cell.frac_coords
+        n_atoms = len(frac_coords)
+
+        # Skip clustering when there is only one atom
+        if n_atoms < 2:
+            # Put the atom to the center
+            termination = frac_coords[0][2] + 0.5
+            return [termination - math.floor(termination)]
+
+        # Compute a Cartesian z-coordinate distance matrix
+        # TODO (@DanielYang59): account for periodic boundary condition
+        dist_matrix = np.zeros((n_atoms, n_atoms), dtype=np.float64)
+        for i, j in itertools.combinations(range(n_atoms), 2):
+            if i != j:
+                z_dist = frac_coords[i][2] - frac_coords[j][2]
+                z_dist = abs(z_dist - round(z_dist)) * self._proj_height
+                dist_matrix[i, j] = z_dist
+                dist_matrix[j, i] = z_dist
+
+        # Cluster the sites by z coordinates
+        z_matrix = linkage(squareform(dist_matrix))
+        clusters = fcluster(z_matrix, ftol, criterion="distance")
+
+        # Generate cluster to z-coordinate mapping
+        clst_loc: dict[np.int32, float] = {clst: frac_coords[idx][2] for idx, clst in enumerate(clusters)}
+
+        # Wrap all clusters into the unit cell ([0, 1) range)
+        possible_clst: list[float] = [coord - math.floor(coord) for coord in sorted(clst_loc.values())]
+
+        # Calculate terminations
+        n_terms = len(possible_clst)
+        terminations: list[float] = []
+        for idx in range(n_terms):
+            # Handle the special case for the first-last pair of
+            # z coordinates (because of periodic boundary condition)
+            if idx == n_terms - 1:
+                termination = (possible_clst[0] + 1 + possible_clst[idx]) * 0.5
+            else:
+                termination = (possible_clst[idx] + possible_clst[idx + 1]) * 0.5
+
+            # Wrap termination to [0, 1) range
+            terminations.append(termination - math.floor(termination))
+
+        return sorted(terminations)
+
     def get_slabs(
         self,
         bonds: dict[tuple[Species | Element | str, Species | Element | str], float] | None = None,
@@ -1275,58 +1330,6 @@ class SlabGenerator:
             list[Slab]: All possible Slabs of a particular surface,
                 sorted by the number of bonds broken.
         """
-
-        def gen_possible_terminations(ftol: float) -> list[float]:
-            """Generate possible terminations by clustering z coordinates.
-
-            Args:
-                ftol (float): Threshold for fcluster to check if
-                    two atoms are on the same plane.
-            """
-            frac_coords = self.oriented_unit_cell.frac_coords
-            n_atoms: int = len(frac_coords)
-
-            # Skip clustering when there is only one atom
-            if n_atoms == 1:
-                # Put the atom to the center
-                termination = frac_coords[0][2] + 0.5
-                return [termination - math.floor(termination)]
-
-            # Compute a Cartesian z-coordinate distance matrix
-            # TODO (@DanielYang59): account for periodic boundary condition
-            dist_matrix: NDArray = np.zeros((n_atoms, n_atoms), dtype=np.float64)
-            for i, j in itertools.combinations(range(n_atoms), 2):
-                if i != j:
-                    z_dist = frac_coords[i][2] - frac_coords[j][2]
-                    z_dist = abs(z_dist - round(z_dist)) * self._proj_height
-                    dist_matrix[i, j] = z_dist
-                    dist_matrix[j, i] = z_dist
-
-            # Cluster the sites by z coordinates
-            z_matrix = linkage(squareform(dist_matrix))
-            clusters = fcluster(z_matrix, ftol, criterion="distance")
-
-            # Generate cluster to z-coordinate mapping
-            clst_loc: dict[Any, float] = {clst: frac_coords[idx][2] for idx, clst in enumerate(clusters)}
-
-            # Wrap all clusters into the unit cell ([0, 1) range)
-            possible_clst: list[float] = [coord - math.floor(coord) for coord in sorted(clst_loc.values())]
-
-            # Calculate terminations
-            n_terms: int = len(possible_clst)
-            terminations: list[float] = []
-            for idx in range(n_terms):
-                # Handle the special case for the first-last pair of
-                # z coordinates (because of periodic boundary condition)
-                if idx == n_terms - 1:
-                    termination = (possible_clst[0] + 1 + possible_clst[idx]) * 0.5
-                else:
-                    termination = (possible_clst[idx] + possible_clst[idx + 1]) * 0.5
-
-                # Wrap termination to [0, 1) range
-                terminations.append(termination - math.floor(termination))
-
-            return sorted(terminations)
 
         def get_z_ranges(
             bonds: dict[tuple[Species | Element | str, Species | Element | str], float],
@@ -1373,7 +1376,7 @@ class SlabGenerator:
         z_ranges = [] if bonds is None else get_z_ranges(bonds, ztol)
 
         slabs: list[Slab] = []
-        for termination in gen_possible_terminations(ftol=ftol):
+        for termination in self.gen_possible_terminations(ftol=ftol):
             # Calculate total number of bonds broken (how often the
             # termination fall within the z_range occupied by a bond)
             bonds_broken = 0

--- a/src/pymatgen/core/surface.py
+++ b/src/pymatgen/core/surface.py
@@ -1287,21 +1287,15 @@ class SlabGenerator:
         # As representative z coordinate, choose the arithmetic mean of the atom fractional z-coordinates
         cluster_zs = sorted(pbc_mean(frac_coords[clusters == cluster_idx, 2]) for cluster_idx in np.unique(clusters))
 
-        # Calculate terminations from ascending cluster z (which is in [0, 1))
-        n_terms = len(cluster_zs)
-        terminations: list[float] = []
-        for idx in range(n_terms):
-            # Handle the special case for the first-last pair of
-            # z coordinates (because of periodic boundary condition)
-            if idx == n_terms - 1:
-                termination = (cluster_zs[0] + 1 + cluster_zs[idx]) * 0.5
-            else:
-                termination = (cluster_zs[idx] + cluster_zs[idx + 1]) * 0.5
+        # Calculate terminations from ascending cluster z (which is in [0, 1)):
+        # Calculate centers between all sequential cluster zs
+        terminations = [0.5 * (cluster_zs[i] + cluster_zs[i + 1]) for i in range(len(cluster_zs) - 1)]
+        # Add the last-first pair, which needs PBC (as first + 1 is outside 0-1)
+        terminations.append((0.5 * (cluster_zs[0] + 1 + cluster_zs[-1])) % 1.0)
 
-            # Wrap termination to [0, 1) range
-            terminations.append(termination - math.floor(termination))
-
-        return sorted(terminations)
+        # Sort to insert the last-first pair at the correct location
+        terminations.sort()
+        return terminations
 
     def get_slabs(
         self,

--- a/src/pymatgen/core/surface.py
+++ b/src/pymatgen/core/surface.py
@@ -1236,15 +1236,16 @@ class SlabGenerator:
             energy=energy,
         )
 
-    def gen_possible_terminations(self, ftol: float) -> list[float]:
+    def gen_possible_terminations(self, ftol: float = 0.1) -> list[float]:
         """Generate possible terminations by clustering z coordinates.
 
         Args:
-            ftol (float): Threshold for fcluster to check if
-                two atoms are on the same plane.
+            ftol (float): Threshold (in the lattice length unit) for fcluster to check if
+                two atoms are on the same plane. Atoms count as part of the cluster if their
+                distance in the surface normal to the next cluster atom is no larger than `ftol`.
 
         Returns:
-            termination_shifts (list[float]): Shifts for terminations that
+            termination_shifts (list[float]): Shifts for terminations that avoid breaking atom clusters.
         """
         frac_coords = self.oriented_unit_cell.frac_coords
         n_atoms = len(frac_coords)
@@ -1271,7 +1272,7 @@ class SlabGenerator:
         clst_loc: dict[np.int32, float] = {clst: frac_coords[idx][2] for idx, clst in enumerate(clusters)}
 
         # Wrap all clusters into the unit cell ([0, 1) range)
-        possible_clst: list[float] = [coord - math.floor(coord) for coord in sorted(clst_loc.values())]
+        possible_clst: list[float] = sorted(coord - math.floor(coord) for coord in clst_loc.values())
 
         # Calculate terminations
         n_terms = len(possible_clst)

--- a/src/pymatgen/core/surface.py
+++ b/src/pymatgen/core/surface.py
@@ -1251,10 +1251,13 @@ class SlabGenerator:
         n_atoms = len(frac_coords)
 
         # Skip clustering when there is only one atom
-        if n_atoms < 2:
+        if n_atoms == 1:
             # Put the atom to the center
             termination = frac_coords[0][2] + 0.5
             return [termination - math.floor(termination)]
+        # For safety, stop empty Structures from progressing further
+        if n_atoms == 0:
+            return []
 
         # Compute a Cartesian z-coordinate distance matrix
         dist_matrix = np.zeros((n_atoms, n_atoms), dtype=np.float64)

--- a/src/pymatgen/core/surface.py
+++ b/src/pymatgen/core/surface.py
@@ -1256,14 +1256,12 @@ class SlabGenerator:
             return [termination - math.floor(termination)]
 
         # Compute a Cartesian z-coordinate distance matrix
-        # TODO (@DanielYang59): account for periodic boundary condition
         dist_matrix = np.zeros((n_atoms, n_atoms), dtype=np.float64)
         for i, j in itertools.combinations(range(n_atoms), 2):
-            if i != j:
-                z_dist = frac_coords[i][2] - frac_coords[j][2]
-                z_dist = abs(z_dist - round(z_dist)) * self._proj_height
-                dist_matrix[i, j] = z_dist
-                dist_matrix[j, i] = z_dist
+            z_dist = frac_coords[i][2] - frac_coords[j][2]
+            z_dist = abs(z_dist - round(z_dist)) * self._proj_height
+            dist_matrix[i, j] = z_dist
+            dist_matrix[j, i] = z_dist
 
         # Cluster the sites by z coordinates
         z_matrix = linkage(squareform(dist_matrix))

--- a/src/pymatgen/core/surface.py
+++ b/src/pymatgen/core/surface.py
@@ -1247,22 +1247,34 @@ class SlabGenerator:
         Returns:
             termination_shifts (list[float]): Shifts for terminations that avoid breaking atom clusters.
         """
+
+        def pbc_mean(frac_z_coord: NDArray) -> float:
+            """Circular mean: Means fractional z coordinates, even across PBC boundaries."""
+            # Angle is periodic in the 0 to 2pi range -> 0 to 1 via *2pi
+            equiv_angle = 2.0 * np.pi * (frac_z_coord)
+            # Compute mean over e^(i*angle)
+            mean = np.mean(np.exp(1j * equiv_angle))
+            # Re-transform mean to angle and then z-coordinate
+            # np.angle returns (-pi, pi] => (-0.5, 0.5] - apply PBC for [0, 1)
+            return float(np.mod(np.angle(mean) / (2.0 * np.pi), 1.0))
+
         frac_coords = self.oriented_unit_cell.frac_coords
         n_atoms = len(frac_coords)
 
-        # Skip clustering when there is only one atom
-        if n_atoms == 1:
-            # Put the atom to the center
-            termination = frac_coords[0][2] + 0.5
-            return [termination - math.floor(termination)]
         # For safety, stop empty Structures from progressing further
         if n_atoms == 0:
             return []
+        # Skip clustering when there is only one atom
+        if n_atoms == 1:
+            # Put the atom to the center
+            termination = frac_coords[0, 2] + 0.5
+            return [termination - math.floor(termination)]
 
         # Compute a Cartesian z-coordinate distance matrix
         dist_matrix = np.zeros((n_atoms, n_atoms), dtype=np.float64)
         for i, j in itertools.combinations(range(n_atoms), 2):
-            z_dist = frac_coords[i][2] - frac_coords[j][2]
+            z_dist = frac_coords[i, 2] - frac_coords[j, 2]
+            # Apply PBC and project onto surface normal
             z_dist = abs(z_dist - round(z_dist)) * self._proj_height
             dist_matrix[i, j] = z_dist
             dist_matrix[j, i] = z_dist
@@ -1271,22 +1283,20 @@ class SlabGenerator:
         z_matrix = linkage(squareform(dist_matrix))
         clusters = fcluster(z_matrix, ftol, criterion="distance")
 
-        # Generate cluster to z-coordinate mapping
-        clst_loc: dict[np.int32, float] = {clst: frac_coords[idx][2] for idx, clst in enumerate(clusters)}
+        # Generate cluster to z-coordinate mapping including PBC
+        # As representative z coordinate, choose the arithmetic mean of the atom fractional z-coordinates
+        cluster_zs = sorted(pbc_mean(frac_coords[clusters == cluster_idx, 2]) for cluster_idx in np.unique(clusters))
 
-        # Wrap all clusters into the unit cell ([0, 1) range)
-        possible_clst: list[float] = sorted(coord - math.floor(coord) for coord in clst_loc.values())
-
-        # Calculate terminations
-        n_terms = len(possible_clst)
+        # Calculate terminations from ascending cluster z (which is in [0, 1))
+        n_terms = len(cluster_zs)
         terminations: list[float] = []
         for idx in range(n_terms):
             # Handle the special case for the first-last pair of
             # z coordinates (because of periodic boundary condition)
             if idx == n_terms - 1:
-                termination = (possible_clst[0] + 1 + possible_clst[idx]) * 0.5
+                termination = (cluster_zs[0] + 1 + cluster_zs[idx]) * 0.5
             else:
-                termination = (possible_clst[idx] + possible_clst[idx + 1]) * 0.5
+                termination = (cluster_zs[idx] + cluster_zs[idx + 1]) * 0.5
 
             # Wrap termination to [0, 1) range
             terminations.append(termination - math.floor(termination))


### PR DESCRIPTION
Currently, `gen_possible_terminations` is an inner function of `SlabGenerator.get_slabs`. With this change it becomes a public function and it can thus be accessed by external users.
This is useful, as it both allows users to see the maximum slab count `get_slabs` can return for this case (reduced by bond breakage and removal of symmetric slabs) and to access a decent termination (compare #105), which will primitivize properly with `Structure.get_primitive_structure`.

The code of the function itself stays unchanged, I only removed some unneeded typing (mypy can infer that).

Side note: Is it intentional that `repair_broken_bonds` is only called if the amount of broken bonds exceeds `max_broken_bonds` (and then allows those slabs to be used)? Personally the docstring (without seeing the code) would make me believe that `max_broken_bonds` is always the maximum number of broken bonds (meaning the amount of returned slabs is dependent on `max_broken_bonds`, but not `repair_broken_bonds`). `repair_broken_bonds` would then repair those slabs.

Also, @DanielYang59 I am not sure if I understand this comment: https://github.com/materialsproject/pymatgen-core/blob/39c044caa68d18af47318011464845a17707484a/src/pymatgen/core/surface.py#L1295-L1303 Doesn't this line account for PBC in z via `abs(z_dist - round(z_dist))`?
https://github.com/materialsproject/pymatgen-core/blob/39c044caa68d18af47318011464845a17707484a/src/pymatgen/core/surface.py#L1301