### PR TITLE
fix latexify_spacegroup

### DIFF
--- a/src/pymatgen/util/string.py
+++ b/src/pymatgen/util/string.py
@@ -248,7 +248,7 @@ def latexify_spacegroup(spacegroup_symbol: str) -> str:
     Returns:
         str: A latex formatted spacegroup with proper subscripts and overlines.
     """
-    sym = re.sub(r"_(\d+)", r"$_{\1}$", spacegroup_symbol)
+    sym = re.sub(r"_(\d)", r"$_{\1}$", spacegroup_symbol)
     return re.sub(r"-(\d)", r"$\\overline{\1}$", sym)
 
 

--- a/tests/util/test_string.py
+++ b/tests/util/test_string.py
@@ -67,6 +67,8 @@ class TestFunc:
             unicodeify("Li0.2Na0.8Cl")
         assert unicodeify_species("O2+") == "O²⁺"
         assert unicodeify_spacegroup("F-3m") == "F3̅m"
+        assert unicodeify_spacegroup("P2_12_12_1") == "P2₁2₁2₁"
+        assert unicodeify_spacegroup("P3_221") == "P3₂21"
 
     def test_formula_double_format(self):
         assert formula_double_format(1.00) == ""


### PR DESCRIPTION

### Problem:
`latexify_spacegroup` used `_(\d+)` to greedily capture one or more digits following an underscore. In Hermann–Mauguin notation, subscript digits (screw axes) are always a single digit — the rotation order is restricted to 1, 2, 3, 4, or 6, and the screw subscript is always less than that order (e.g. 6₁–6₅, 4₁–4₃, 3₁–3₂, 2₁). When multiple axes are concatenated with no separator, the greedy match incorrectly consumes the next axis's rotation-order digit into the current subscript.

### Fix:
Change _(\d+) → _(\d) everywhere so exactly one digit is captured per subscript.


### Example — space group 19:
```
Input:    P2_12_12_1
Original: P2_12_12₁
Fix:      P2₁2₁2₁
```

### Tests:
Added two test cases: `P2_12_12_1` -> `P2₁2₁2₁` (space group 19) and `P3_221` -> `P3₂21` (space group 154)


## Checklist

- [x] Google format doc strings added. Check with `ruff`.
- [x] Type annotations included. Check with `mypy`.
- [x] Tests added for new features/fixes.
