### PR TITLE
Fix incorrect determinant calculation in `hkl_transformation`, add `uvw_transformation`

### DIFF
--- a/src/pymatgen/core/surface.py
+++ b/src/pymatgen/core/surface.py
@@ -2277,25 +2277,27 @@ def _is_in_miller_family(
 
 def hkl_transformation(
     transf: NDArray,
-    miller_index: tuple[int, ...] | NDArray,
+    miller_index: tuple[int, int, int] | NDArray,
 ) -> tuple[int, int, int]:
     """Transform the Miller index from setting A to B with a transformation matrix.
 
     Args:
         transf (3x3 array): The matrix that transforms a lattice A to B via B = transf @ A.
-        miller_index (tuple[int, ...]): The Miller index (h, k, l) to transform.
+        miller_index (tuple[int, int, int]): The Miller index (h, k, l) to transform.
+
+    Returns:
+        transformed_miller_index (tuple[int, int, int]): The Miller index in setting B.
     """
     # Convert the elements of the transformation matrix to integers
     fractions = [Fraction(value).limit_denominator(100) for value in itertools.chain.from_iterable(transf)]
     reduced_transf = np.rint(math.lcm(*(f.denominator for f in fractions)) * transf).astype(int)
 
     # Perform the transformation
-    transf_hkl = np.dot(reduced_transf, miller_index)
-    divisor = abs(reduce(math.gcd, transf_hkl))  # type: ignore[arg-type]
-    transf_hkl = np.array([idx // divisor for idx in transf_hkl])
+    transf_hkl = reduced_transf @ np.asarray(miller_index, dtype=int)
+    transf_hkl //= math.gcd(*transf_hkl)
 
-    # Get positive Miller index
-    if sum(idx < 0 for idx in transf_hkl) > 1:
+    # Get positive Miller index (first nonzero index positive)
+    if next(index for index in transf_hkl if index != 0):
         transf_hkl *= -1
 
     return tuple(transf_hkl)

--- a/src/pymatgen/core/surface.py
+++ b/src/pymatgen/core/surface.py
@@ -2275,7 +2275,7 @@ def _is_in_miller_family(
     return any(in_coord_list(miller_list, op.operate(miller_index)) for op in symm_ops)
 
 
-def _index_transformation(transf: NDArray, index: tuple[int, int, int] | NDArray):
+def _index_transformation(transf: NDArray, index: tuple[int, int, int] | NDArray) -> NDArray[int]:
     """Transforms a given index via transf @ index, while avoiding floats."""
     # Convert the elements of the transformation matrix to integers
     fractions = [Fraction(value).limit_denominator(100) for value in itertools.chain.from_iterable(transf)]
@@ -2304,10 +2304,10 @@ def hkl_transformation(transf: NDArray, miller_index: tuple[int, int, int] | NDA
     if next(index for index in transf_hkl if index != 0) < 0:
         transf_hkl *= -1
 
-    return tuple(transf_hkl)
+    return cast("tuple[int, int, int]", tuple(transf_hkl))
 
 
-def uvw_transformation(transf: NDArray, uvw: tuple[int, int, int] | NDArray):
+def uvw_transformation(transf: NDArray, uvw: tuple[int, int, int] | NDArray) -> tuple[int, int, int]:
     """Transform the direction index (uvw) from setting A to B with a transformation matrix.
 
     Args:
@@ -2317,7 +2317,7 @@ def uvw_transformation(transf: NDArray, uvw: tuple[int, int, int] | NDArray):
     Returns:
         transformed_direction_index (tuple[int, int, int]): The direction index in setting B.
     """
-    return tuple(_index_transformation(np.linalg.inv(transf).T, uvw))
+    return cast("tuple[int, int, int]", tuple(_index_transformation(np.linalg.inv(transf).T, uvw)))
 
 
 def miller_index_from_sites(

--- a/src/pymatgen/core/surface.py
+++ b/src/pymatgen/core/surface.py
@@ -2275,11 +2275,20 @@ def _is_in_miller_family(
     return any(in_coord_list(miller_list, op.operate(miller_index)) for op in symm_ops)
 
 
-def hkl_transformation(
-    transf: NDArray,
-    miller_index: tuple[int, int, int] | NDArray,
-) -> tuple[int, int, int]:
-    """Transform the Miller index from setting A to B with a transformation matrix.
+def _index_transformation(transf: NDArray, index: tuple[int, int, int] | NDArray):
+    """Transforms a given index via transf @ index, while avoiding floats."""
+    # Convert the elements of the transformation matrix to integers
+    fractions = [Fraction(value).limit_denominator(100) for value in itertools.chain.from_iterable(transf)]
+    reduced_transf = np.rint(math.lcm(*(f.denominator for f in fractions)) * transf).astype(int)
+
+    # Perform the transformation
+    transf_hkl = reduced_transf @ np.asarray(index, dtype=int)
+    transf_hkl //= math.gcd(*transf_hkl)
+    return transf_hkl
+
+
+def hkl_transformation(transf: NDArray, miller_index: tuple[int, int, int] | NDArray) -> tuple[int, int, int]:
+    """Transform the Miller index (hkl) from setting A to B with a transformation matrix.
 
     Args:
         transf (3x3 array): The matrix that transforms a lattice A to B via B = transf @ A.
@@ -2287,20 +2296,28 @@ def hkl_transformation(
 
     Returns:
         transformed_miller_index (tuple[int, int, int]): The Miller index in setting B.
+            Its first nonzero index is positive.
     """
-    # Convert the elements of the transformation matrix to integers
-    fractions = [Fraction(value).limit_denominator(100) for value in itertools.chain.from_iterable(transf)]
-    reduced_transf = np.rint(math.lcm(*(f.denominator for f in fractions)) * transf).astype(int)
-
-    # Perform the transformation
-    transf_hkl = reduced_transf @ np.asarray(miller_index, dtype=int)
-    transf_hkl //= math.gcd(*transf_hkl)
+    transf_hkl = _index_transformation(transf, miller_index)
 
     # Get positive Miller index (first nonzero index positive)
-    if next(index for index in transf_hkl if index != 0):
+    if next(index for index in transf_hkl if index != 0) < 0:
         transf_hkl *= -1
 
     return tuple(transf_hkl)
+
+
+def uvw_transformation(transf: NDArray, uvw: tuple[int, int, int] | NDArray):
+    """Transform the direction index (uvw) from setting A to B with a transformation matrix.
+
+    Args:
+        transf (3x3 array): The matrix that transforms a lattice A to B via B = transf @ A.
+        uvw (tuple[int, int, int]): The direction index (u, v, w) to transform.
+
+    Returns:
+        transformed_direction_index (tuple[int, int, int]): The direction index in setting B.
+    """
+    return tuple(_index_transformation(np.linalg.inv(transf).T, uvw))
 
 
 def miller_index_from_sites(

--- a/src/pymatgen/core/surface.py
+++ b/src/pymatgen/core/surface.py
@@ -20,6 +20,7 @@ import logging
 import math
 import os
 import warnings
+from fractions import Fraction
 from functools import reduce
 from typing import TYPE_CHECKING, Literal, cast, overload
 
@@ -2275,18 +2276,18 @@ def _is_in_miller_family(
 
 
 def hkl_transformation(
-    transf: np.ndarray,
-    miller_index: tuple[int, ...],
+    transf: NDArray,
+    miller_index: tuple[int, ...] | NDArray,
 ) -> tuple[int, int, int]:
     """Transform the Miller index from setting A to B with a transformation matrix.
 
     Args:
-        transf (3x3 array): The matrix that transforms a lattice from A to B.
-        miller_index (tuple[int, ...]): The Miller index [h, k, l] to transform.
+        transf (3x3 array): The matrix that transforms a lattice A to B via B = transf @ A.
+        miller_index (tuple[int, ...]): The Miller index (h, k, l) to transform.
     """
     # Convert the elements of the transformation matrix to integers
-    reduced_transf = reduce(math.lcm, [int(1 / i) for i in itertools.chain(*transf) if i != 0]) * transf
-    reduced_transf = reduced_transf.astype(int)
+    fractions = [Fraction(value).limit_denominator(100) for value in itertools.chain.from_iterable(transf)]
+    reduced_transf = np.rint(math.lcm(*(f.denominator for f in fractions)) * transf).astype(int)
 
     # Perform the transformation
     transf_hkl = np.dot(reduced_transf, miller_index)

--- a/tests/core/test_surface.py
+++ b/tests/core/test_surface.py
@@ -878,9 +878,11 @@ class TestMillerIndexFinder(MatSciTest):
             167, Lattice.hexagonal(5, 7), ("Ca", "C", "O"), ((0, 0, 0), (0, 0, 0.25), (0.25, 0, 0.25))
         )
 
+        matrix = SpacegroupAnalyzer(struct).get_conventional_to_primitive_transformation_matrix()
+
         # Both have gcd 3: (6, 3, 3) and [3, -3, -3]
-        assert hkl_transformation(struct, (1, 0, 4)) == (2, 1, 1)
-        assert uvw_transformation(struct, (4, 2, -1)) == (1, -1, -1)
+        assert hkl_transformation(matrix, (1, 0, 4)) == (2, 1, 1)
+        assert uvw_transformation(matrix, (4, 2, -1)) == (1, -1, -1)
 
     def test_get_symmetrically_equivalent_miller_indices(self):
         # Tests to see if the function obtains all equivalent hkl for cubic (100)

--- a/tests/core/test_surface.py
+++ b/tests/core/test_surface.py
@@ -20,7 +20,9 @@ from pymatgen.core.surface import (
     get_slab_regions,
     get_symmetrically_distinct_miller_indices,
     get_symmetrically_equivalent_miller_indices,
+    hkl_transformation,
     miller_index_from_sites,
+    uvw_transformation,
 )
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 from pymatgen.symmetry.groups import SpaceGroup
@@ -861,6 +863,24 @@ class TestMillerIndexFinder(MatSciTest):
         tetra_conv_exp = [(1, 0, 0), (0, 0, 1), (1, 1, 0), (1, 0, 1), (1, 1, 1)]
         tetra = Structure(Lattice.tetragonal(2, 3), ["H"], [[0, 0, 0]])
         assert get_symmetrically_distinct_miller_indices(tetra, 1) == tetra_conv_exp
+
+    def test_hkl_uvw_transformation(self):
+        """Test hkl/uvw_transformation for reasonable results."""
+        # hkls should be reduced
+        matrix = np.eye(3)
+        assert hkl_transformation(matrix, (2, 2, 2)) == (1, 1, 1)
+        # hkl_transformation should use the correct determinant
+        matrix[0, 0] = 2 / 3
+        assert hkl_transformation(matrix, (3, 1, 0)) == (2, 1, 0)
+
+        # Test a realistic scenario
+        struct = Structure.from_spacegroup(
+            167, Lattice.hexagonal(5, 7), ("Ca", "C", "O"), ((0, 0, 0), (0, 0, 0.25), (0.25, 0, 0.25))
+        )
+
+        # Both have gcd 3: (6, 3, 3) and [3, -3, -3]
+        assert hkl_transformation(struct, (1, 0, 4)) == (2, 1, 1)
+        assert uvw_transformation(struct, (4, 2, -1)) == (1, -1, -1)
 
     def test_get_symmetrically_equivalent_miller_indices(self):
         # Tests to see if the function obtains all equivalent hkl for cubic (100)


### PR DESCRIPTION
This PR greatly changes `hkl_transformation`:
Currently, `hkl_transformation` calculates the denominator of the transformation matrix elements via
```py
[int(1 / i) for i in itertools.chain(*transf) if i != 0]
```
This works if the fraction is `1/n`, but for other cases (e. g. the `2/3` in R-decentering) the result is wrong.
Also, the previous hkl convention was
```py
sum(idx < 0 for idx in transf_hkl) <= 1
```
Meaning no more than one index can be negative. This is problematic for indices like (-1, 0, 0), where (1, 0, 0) is preferred. This has been changed to the same convention as in #101: First index positive. **This may affect the returned hkl in some cases, where both are reasonable, e. g.  now (1, -1, -2) was (-1, 1, 2) before.**

Also, `uvw_transformation` has been added, using the same code (but avoiding the index inversion) with the transposed inverted matrix instead of the matrix itself.

## Checklist

- [x] Google format doc strings added. Check with `ruff`.
- [x] Type annotations included. Check with `mypy`.
- [x] Tests added for new features/fixes.
