### PR TITLE
Revert most of #106 for mypy compatibility

### DIFF
--- a/src/pymatgen/core/surface.py
+++ b/src/pymatgen/core/surface.py
@@ -2082,8 +2082,8 @@ def get_symmetrically_equivalent_miller_indices(
 def get_symmetrically_distinct_miller_indices(
     structure: Structure | IStructure,
     max_index: int,
-    return_hkil: Literal[False],
-    cell: Literal["input", "conventional", "primitive", "conv_np", "prim_2conv"],
+    return_hkil: Literal[False] = False,
+    cell: Literal["input", "conventional", "primitive", "conv_np", "prim_2conv"] = "input",
 ) -> list[tuple[int, int, int]]: ...
 
 
@@ -2092,7 +2092,7 @@ def get_symmetrically_distinct_miller_indices(
     structure: Structure | IStructure,
     max_index: int,
     return_hkil: Literal[True],
-    cell: Literal["input", "conventional", "primitive", "conv_np", "prim_2conv"],
+    cell: Literal["input", "conventional", "primitive", "conv_np", "prim_2conv"] = "input",
 ) -> list[tuple[int, int, int, int]]: ...
 
 


### PR DESCRIPTION
In #106 I removed some of the type hints from #101 as they did not generate mypy errors in my testing when missing.
However, if only `cell` is given and `return_hkil` is not, mypy does not use the set default from the non-overload to infer the result.
Therefore, the default `False` must be exposed (but not True) to enable a use like this (without mypy errors):
```py
get_symmetrically_distinct_miller_indices(structure, max_index, cell="conventional")
```

- [x] Type annotations included. Check with `mypy`.

