### PR TITLE
Remove two xfail marks for vasp test

### DIFF
--- a/tests/io/vasp/test_inputs.py
+++ b/tests/io/vasp/test_inputs.py
@@ -1843,15 +1843,16 @@ class TestPotcar(MatSciTest):
         assert self.potcar.symbols == ["Fe_pv", "O"]
         assert self.potcar[0].nelectrons == 14
 
-    @pytest.mark.xfail(reason="TODO: need someone to fix this")
     def test_default_functional(self):
-        potcar = Potcar(["Fe", "P"])
-        assert potcar[0].functional_class == "GGA"
-        assert potcar[1].functional_class == "GGA"
-        SETTINGS["PMG_DEFAULT_FUNCTIONAL"] = "LDA"
-        potcar = Potcar(["Fe", "P"])
-        assert potcar[0].functional_class == "LDA"
-        assert potcar[1].functional_class == "LDA"
+        with patch.dict(SETTINGS, PMG_DEFAULT_FUNCTIONAL="PBE"):
+            potcar = Potcar(["Fe", "P"])
+            assert potcar[0].functional_class == "GGA"
+            assert potcar[1].functional_class == "GGA"
+
+        with patch.dict(SETTINGS, PMG_DEFAULT_FUNCTIONAL="LDA"):
+            potcar = Potcar(["Fe", "P"])
+            assert potcar[0].functional_class == "LDA"
+            assert potcar[1].functional_class == "LDA"
 
     def test_pickle(self):
         pickle.dumps(self.potcar)

--- a/tests/io/vasp/test_sets.py
+++ b/tests/io/vasp/test_sets.py
@@ -1783,9 +1783,8 @@ class TestMVLScanRelaxSet(MatSciTest):
         ):
             MVLScanRelaxSet(self.struct, user_potcar_functional="PBE")
 
-    @pytest.mark.xfail(reason="TODO: need someone to fix this")
     @skip_if_no_psp_dir
-    def test_potcar_need_fix(self):
+    def test_potcar_functional_and_settings(self):
         test_potcar_set_1 = self.set(self.struct, user_potcar_functional="PBE_54")
         assert test_potcar_set_1.potcar.functional == "PBE_54"
 
@@ -1810,10 +1809,9 @@ class TestMVLScanRelaxSet(MatSciTest):
                     user_potcar_functional="PBE_54",
                     user_potcar_settings=user_potcar_settings,
                 )
-                expected = {
-                    **({"W": "W_sv"} if "W" in struct.symbol_set else {}),
-                    **(user_potcar_settings or {}),
-                }
+                expected = user_potcar_settings
+                if "W" in struct.symbol_set:
+                    expected = {"W": "W_sv", **(user_potcar_settings or {})}
                 assert relax_set.user_potcar_settings == expected
 
     def test_as_from_dict(self):


### PR DESCRIPTION
- scoped PMG_DEFAULT_FUNCTIONAL with patch.dict in tests/io/vasp/test_inputs.py, preventing global settings leakage
- in tests/io/vasp/test_sets.py; the expected value now correctly remains None when no POTCAR overrides or W-specific override apply