### PR TITLE
Accelerate ``FermiDos.get_e_h_concs`` (and thus ``get_doping``)

### DIFF
--- a/src/pymatgen/electronic_structure/dos.py
+++ b/src/pymatgen/electronic_structure/dos.py
@@ -465,6 +465,12 @@ class FermiDos(Dos, MSONable):
             self.energies[: self.idx_mid_gap] -= (bandgap - (ecbm - evbm)) / 2.0
             self.energies[self.idx_mid_gap :] += (bandgap - (ecbm - evbm)) / 2.0
 
+        # Precompute trapezoid integration weights folded with the DOS, so ``get_e_h_concs`` reduces to a
+        # dot product of these weights with Fermi-Dirac occupation factors (much faster):
+        ih, ie = self.idx_h_integration, self.idx_e_integration
+        self._h_weights = _trapezoid_weights(self.energies[:ih]) * self.tdos[:ih]
+        self._e_weights = _trapezoid_weights(self.energies[ie:]) * self.tdos[ie:]
+
     def get_e_h_concs(self, fermi_level: float, temperature: float) -> tuple[float, float]:
         """
         Get the electron and hole concentrations (in cm^-3) at a given Fermi
@@ -478,21 +484,18 @@ class FermiDos(Dos, MSONable):
             tuple[float, float]: The electron and hole concentrations in cm^-3.
         """
         scale = self.volume * self.A_to_cm**3
+        kbt = _constant("Boltzmann constant in eV/K") * temperature
         ih, ie = self.idx_h_integration, self.idx_e_integration
-        e_conc: float = (
-            trapezoid(  # use trapezoid rule for accurate DOS integration
-                self.tdos[ie:] * f0(self.energies[ie:], fermi_level, temperature),
-                x=self.energies[ie:],
-            )
-            / scale
-        )
-        h_conc: float = (
-            trapezoid(
-                self.tdos[:ih] * f0(-self.energies[:ih], -fermi_level, temperature),
-                x=self.energies[:ih],
-            )
-            / scale
-        )
+
+        # Fermi-Dirac distribution exponentially decays away from band edge / Fermi level, so truncate the
+        # integration at 40 k_BT from these bounds (< ~1e-10 - 1e-14 relative error, ~3-10x speedup)
+        i_max = max(int(np.searchsorted(self.energies, max(fermi_level, self.energies[self.idx_cbm]) + 40 * kbt)), ie)
+        i_min = min(int(np.searchsorted(self.energies, min(fermi_level, self.energies[self.idx_vbm]) - 40 * kbt)), ih)
+
+        # equivalent to trapezoid(tdos * f0, x=energies) over the (truncated) integration ranges,
+        # using precomputed weights ; expit(-x) = f0 = 1/(1+exp(x)):
+        e_conc: float = self._e_weights[: i_max - ie] @ expit(-(self.energies[ie:i_max] - fermi_level) / kbt) / scale
+        h_conc: float = self._h_weights[i_min:] @ expit((self.energies[i_min:ih] - fermi_level) / kbt) / scale
 
         return e_conc, h_conc
 
@@ -1584,6 +1587,20 @@ def f0(E: float | NDArray, fermi: float, T: float) -> float:
     """
     exponent = (E - fermi) / (_constant("Boltzmann constant in eV/K") * T)
     return expit(-exponent)  # scipy logistic sigmoid function; expit(x) = 1/(1+exp(-x))
+
+
+def _trapezoid_weights(x: NDArray) -> NDArray:
+    """
+    Get weights ``w(x)`` such that ``w(x) @ y == trapezoid(y, x=x)``
+    for any ``y`` on the fixed grid ``x``.
+    """
+    weights = np.zeros_like(x)  # same shape as ``x``
+    if len(x) > 1:
+        dx = np.diff(x)
+        weights[0] = dx[0] / 2
+        weights[-1] = dx[-1] / 2
+        weights[1:-1] = (dx[:-1] + dx[1:]) / 2  # trapezoid weights
+    return weights
 
 
 def _get_orb_type_lobster(orb: str) -> OrbitalType | None:


### PR DESCRIPTION
## Summary

This small change adds a major acceleration for `FermiDos.get_e_h_concs` (and hence `FermiDos.get_doping` and `FermiDos.get_fermi`); making it 3–10+× faster with identical results (to within ~float noise, ~1e-12 _relative_ error). 

Two main changes (in `dos.py`):

1. Precomputed trapezoid weights in `FermiDos.__init__`: because we have a fixed energy grid, `trapezoid(y, x)` is just a dot product `w @ y`, so this removes per-call `scipy` dispatch overhead and the weights are folded with `tdos` once (rather than every call). 
2. Fermi-Dirac truncation: the Fermi-Dirac distribution decays as `exp(-|E−E_F|/kT)` away from the Fermi level, so beyond ~40 k_BT the contribution is negligible (~<1e-17, relative) and thus can be truncated, greatly reducing the integration range.

Passes built-in DOS tests, and tested extensively indirectly via the `doped` defect/carrier concentration analyses for a range of system DOSs and Fermi Levels. Speedup of ~3-10+x.

## Checklist

- [ ] Google format doc strings added. Check with `ruff`.
- [x] Type annotations included. Check with `mypy`.
- [ ] Tests added for new features/fixes.
- [ ] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))
