### PR TITLE
fix minor logic for POTCAR validation

### DIFF
--- a/src/pymatgen/io/vasp/inputs.py
+++ b/src/pymatgen/io/vasp/inputs.py
@@ -2516,10 +2516,23 @@ class PotcarSingle:
 
         data_match = False
         if key_match:
+            # Use a magnitude-relative tolerance. Summary-stat values (especially
+            # VAR) reach ~1e12 for heavy elements, where a value stored in
+            # potcar-summary-stats.json (round-tripped through JSON) differs from a
+            # freshly-parsed one by 1-2 float64 ULPs -- far larger than a fixed
+            # absolute tolerance, yet not a real difference. Scaling by
+            # max(|a|, |b|, 1) fixes those false mismatches while remaining
+            # effectively absolute (scale == 1) for small-magnitude quantities.
             data_diff = [
-                abs(potcar_stats_1["stats"].get(key, {}).get(stat) - potcar_stats_2["stats"].get(key, {}).get(stat))
+                abs(v1 - v2) / max(abs(v1), abs(v2), 1.0)
                 for stat in ("MEAN", "ABSMEAN", "VAR", "MIN", "MAX")
                 for key in check_potcar_fields
+                for v1, v2 in [
+                    (
+                        potcar_stats_1["stats"].get(key, {}).get(stat),
+                        potcar_stats_2["stats"].get(key, {}).get(stat),
+                    )
+                ]
             ]
             data_match = all(np.array(data_diff) < tolerance)
 

--- a/tests/io/vasp/test_inputs.py
+++ b/tests/io/vasp/test_inputs.py
@@ -2018,6 +2018,42 @@ def test_potcar_summary_stats() -> None:
         assert actual == expected, f"{key=}, {expected=}, {actual=}"
 
 
+def test_compare_potcar_stats_relative_tolerance() -> None:
+    """compare_potcar_stats uses a magnitude-relative tolerance.
+
+    Summary-stat values (especially VAR) reach ~1e12 for heavy elements. A value
+    stored in potcar-summary-stats.json and re-parsed can differ from a freshly
+    computed one by 1-2 float64 ULPs -- far larger than the 1e-6 tolerance in
+    absolute terms, but not a real difference. Such pairs must still match, while
+    a genuinely different value must not.
+    """
+    reference = {
+        "keywords": {"header": ["titel", "zval"], "data": ["localpart"]},
+        "stats": {
+            "header": {"MEAN": 32.8, "ABSMEAN": 32.8, "VAR": 1.0e4, "MIN": 0.0, "MAX": 8.1e2},
+            "data": {
+                "MEAN": 172565.99127092774,
+                "ABSMEAN": 172585.5792270369,
+                "VAR": 2551106075405.738,  # ~2.55e12; 1 ULP ~5e-4 in absolute terms
+                "MIN": -239.142614172,
+                "MAX": 23770213.0296,
+            },
+        },
+    }
+
+    # A one-ULP perturbation of the large VAR (what JSON round-tripping introduces)
+    # must still be treated as a match.
+    one_ulp_off = copy.deepcopy(reference)
+    one_ulp_off["stats"]["data"]["VAR"] = np.nextafter(reference["stats"]["data"]["VAR"], np.inf)
+    assert np.nextafter(reference["stats"]["data"]["VAR"], np.inf) != reference["stats"]["data"]["VAR"]
+    assert PotcarSingle.compare_potcar_stats(reference, one_ulp_off)
+
+    # A genuinely different VAR (relative difference well above tolerance) must not.
+    genuinely_different = copy.deepcopy(reference)
+    genuinely_different["stats"]["data"]["VAR"] *= 1.001
+    assert not PotcarSingle.compare_potcar_stats(reference, genuinely_different)
+
+
 def test_gen_potcar_summary_stats() -> None:
     assert set(_SUMM_STATS) == set(PotcarSingle.functional_dir)
 


### PR DESCRIPTION
Minor fix for the logic around POTCAR validation. Ensures that last-digit discrepancies for very large, squared quantities do not cause a POTCAR to be marked as invalid