### PR TITLE
Allow Strain initialization from Voigt vectors

### DIFF
--- a/src/pymatgen/core/elasticity/strain.py
+++ b/src/pymatgen/core/elasticity/strain.py
@@ -169,6 +169,9 @@ class Strain(SquareTensor):
             strain_matrix (ArrayLike): 3x3 matrix or length-6 Voigt notation vector
                 representing the Green-Lagrange strain
         """
+        if np.shape(strain_matrix) == (6,):
+            return cls.from_voigt(strain_matrix)
+
         vscale = np.ones((6,))
         vscale[3:] *= 2
         obj = super().__new__(cls, strain_matrix, vscale=vscale)

--- a/tests/core/elasticity/test_strain.py
+++ b/tests/core/elasticity/test_strain.py
@@ -93,6 +93,7 @@ class TestStrain(MatSciTest):
     def test_new(self):
         test_strain = Strain([[0, 0.01, 0], [0.01, 0.0002, 0], [0, 0, 0]])
         assert_allclose(test_strain, test_strain.get_deformation_matrix().green_lagrange_strain)
+        assert_allclose(Strain(test_strain.voigt), test_strain)
         with pytest.raises(
             ValueError,
             match="Strain must be initialized with a symmetric array or a Voigt-notation vector",


### PR DESCRIPTION
`Strain` is documented to accept a six-element Voigt vector, but passing one currently raises a rank error in `SquareTensor`.

This change detects that input and uses the existing `from_voigt` conversion. That also handles the factor-of-two scaling for shear components correctly.

I added a round-trip test with a nonzero shear component to cover the bug.

Fixes materialsproject/pymatgen#4549