### PR TITLE
Handle missing exponent markers in OSZICAR

### DIFF
--- a/src/pymatgen/io/vasp/outputs.py
+++ b/src/pymatgen/io/vasp/outputs.py
@@ -4716,6 +4716,8 @@ class Oszicar:
         electronic_steps = []
         ionic_steps = []
         ionic_general_pattern = re.compile(r"(\w+)=\s*(\S+)")
+        # VASP can omit the exponent marker for exponents with three digits.
+        missing_exponent_pattern = re.compile(r"(?<=\d)([+-]\d+)$")
         electronic_pattern = re.compile(r"\s*\w+\s*:(.*)")
 
         header: list = []
@@ -4734,7 +4736,9 @@ class Oszicar:
                 elif line.strip() != "":
                     # remove space first and apply field agnostic extraction
                     matches = re.findall(ionic_general_pattern, re.sub(r"d E ", "dE", line))
-                    ionic_steps.append({key: _vasprun_float(value) for key, value in matches})
+                    ionic_steps.append(
+                        {key: _vasprun_float(missing_exponent_pattern.sub(r"E\1", value)) for key, value in matches}
+                    )
 
         self.electronic_steps = electronic_steps
         self.ionic_steps = ionic_steps

--- a/src/pymatgen/io/vasp/outputs.py
+++ b/src/pymatgen/io/vasp/outputs.py
@@ -4707,6 +4707,7 @@ class Oszicar:
         """
 
         def smart_convert(header: str, num: float | str) -> float | str:
+            num = missing_exponent_pattern.sub(r"E\1", str(num))
             try:
                 return int(num) if header in {"N", "ncg"} else float(num)
 
@@ -4716,7 +4717,7 @@ class Oszicar:
         electronic_steps = []
         ionic_steps = []
         ionic_general_pattern = re.compile(r"(\w+)=\s*(\S+)")
-        # VASP can omit the exponent marker for exponents with three digits.
+        # VASP can omit the exponent marker before a trailing signed exponent.
         missing_exponent_pattern = re.compile(r"(?<=\d)([+-]\d+)$")
         electronic_pattern = re.compile(r"\s*\w+\s*:(.*)")
 

--- a/tests/io/vasp/test_outputs.py
+++ b/tests/io/vasp/test_outputs.py
@@ -1603,11 +1603,20 @@ DAV:   1     0.831012218308E+03    0.83101E+03   -0.25939E+05  4672   0.894E+02
     def test_missing_exponent_marker(self):
         oszicar_path = Path(self.tmp_path) / "OSZICAR"
         oszicar_path.write_text(
-            "1 F= -.16497036E+04 E0= -.16497036E+04 d E =-.302333-128 mag= 13.9998\n",
+            """\
+       N       E                     dE             d eps       ncg     rms          rms(c)
+DAV:   1    -.16497036E+04       -.302333-128   -0.25939E+05  4672   0.894E+02
+       1 F= -.16497036E+04 E0= -.16497036E+04 d E =-.302333-128 mag= 13.9998
+""",
             encoding="utf-8",
         )
 
-        ionic_step = Oszicar(oszicar_path).ionic_steps[0]
+        oszicar = Oszicar(oszicar_path)
+        electronic_step = oszicar.electronic_steps[0][0]
+        assert electronic_step["E"] == approx(-1649.7036)
+        assert electronic_step["dE"] == float("-.302333E-128")
+
+        ionic_step = oszicar.ionic_steps[0]
         assert ionic_step["F"] == approx(-1649.7036)
         assert ionic_step["E0"] == approx(-1649.7036)
         assert ionic_step["dE"] == float("-.302333E-128")

--- a/tests/io/vasp/test_outputs.py
+++ b/tests/io/vasp/test_outputs.py
@@ -1600,6 +1600,19 @@ DAV:   1     0.831012218308E+03    0.83101E+03   -0.25939E+05  4672   0.894E+02
         assert ionic_step["E"] == approx(648_764.04)
         assert ionic_step["F"] == approx(492_203.67)
 
+    def test_missing_exponent_marker(self):
+        oszicar_path = Path(self.tmp_path) / "OSZICAR"
+        oszicar_path.write_text(
+            "1 F= -.16497036E+04 E0= -.16497036E+04 d E =-.302333-128 mag= 13.9998\n",
+            encoding="utf-8",
+        )
+
+        ionic_step = Oszicar(oszicar_path).ionic_steps[0]
+        assert ionic_step["F"] == approx(-1649.7036)
+        assert ionic_step["E0"] == approx(-1649.7036)
+        assert ionic_step["dE"] == float("-.302333E-128")
+        assert ionic_step["mag"] == approx(13.9998)
+
 
 class TestGetBandStructureFromVaspMultipleBranches:
     def test_read_multi_branches(self):


### PR DESCRIPTION
VASP can occasionally omit the `E` from very small values in `OSZICAR`. For example, it may write `-.302333-128` instead of `-.302333E-128`, which currently causes the parser to lose the value or raise a conversion error.

This restores the exponent marker before converting values from both electronic and ionic steps. The pattern is limited to a trailing signed exponent whose sign follows a digit, so regular decimals and standard scientific notation such as `E+04` are left unchanged.

The regression test covers the malformed value in both step types and checks that a normal `E+04` value is still parsed normally.

Fixes materialsproject/pymatgen#3699