### PR TITLE
Keep phonon thermodynamic integrals finite when the DOS samples omega = 0

### DIFF
--- a/src/pymatgen/phonon/dos.py
+++ b/src/pymatgen/phonon/dos.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import warnings
 from typing import TYPE_CHECKING, Literal, NamedTuple
 
 import numpy as np
@@ -28,7 +29,7 @@ THZ_TO_J = const.value("hertz-joule relationship") * const.tera
 
 
 def _thermo_integrand(
-    freqs: NDArray, dens: NDArray, weight: Callable[[NDArray], NDArray], zero_freq_weight: float
+    freqs: NDArray, dens: NDArray, weight: Callable[[NDArray], NDArray], zero_freq_weight: float | None
 ) -> NDArray:
     """Build the integrand weight(freqs) * dens for a thermodynamic DOS integral.
 
@@ -44,18 +45,38 @@ def _thermo_integrand(
         freqs: non-negative frequencies, ascending.
         dens: densities corresponding to freqs.
         weight: the Bose-Einstein weight, evaluated only where freqs > 0.
-        zero_freq_weight: value used where freqs == 0. For C_v and U this is the exact
-            limit of the weight. For S and F the weight itself diverges logarithmically,
-            but the divergence is integrable and any physical phonon DOS vanishes as
-            omega -> 0 (g(omega) ~ omega^2), so the omega = 0 sample contributes nothing
-            and 0 is used.
+        zero_freq_weight: value used where freqs == 0, or None when the weight has no
+            finite limit there. C_v and U have exact limits (1 and 2kT). The S and F
+            weights instead diverge logarithmically; the divergence is integrable, so
+            dropping the omega = 0 sample converges to the correct integral, and it is
+            exactly zero for the harmonic lattice DOS these functions model, which
+            vanishes as g(omega) ~ omega^2. A DOS with g(0) > 0 -- e.g. a VDOS from the
+            velocity autocorrelation of a diffusive MD trajectory -- is outside that
+            model and would need the first panel resolved (or a two-phase treatment of
+            the diffusive component), so warn instead of quietly under-integrating.
 
     Returns:
         NDArray: the integrand, finite everywhere freqs and dens are finite.
     """
-    weights = np.full_like(freqs, zero_freq_weight, dtype=float)
     positive = freqs > 0
+    weights = np.zeros_like(freqs, dtype=float)
     weights[positive] = weight(freqs[positive])
+
+    if zero_freq_weight is None:
+        zero_freq_dens = dens[~positive]
+        if zero_freq_dens.size and np.any(zero_freq_dens != 0):
+            warnings.warn(
+                f"DOS has non-zero density {np.max(zero_freq_dens)} at omega = 0, where the entropy and "
+                "free-energy weights diverge logarithmically. The omega = 0 sample is dropped, so the result "
+                "is under-integrated by O(delta * log delta) in the frequency spacing. Refine the grid near "
+                "zero, or note that a DOS with g(0) > 0 (a diffusive VDOS, say) is outside the harmonic "
+                "oscillator model these functions assume.",
+                UserWarning,
+                stacklevel=3,
+            )
+    else:
+        weights[~positive] = zero_freq_weight
+
     return weights * dens
 
 
@@ -232,7 +253,7 @@ class PhononDos(MSONable):
             return wd2kt**2 / np.sinh(wd2kt) ** 2
 
         # x**2 / sinh(x)**2 -> 1 as x -> 0
-        cv = np.trapezoid(_thermo_integrand(freqs, dens, cv_weight, 1.0), x=freqs)
+        cv = float(np.trapezoid(_thermo_integrand(freqs, dens, cv_weight, 1.0), x=freqs))
         cv *= const.Boltzmann * const.Avogadro
 
         if structure:
@@ -270,7 +291,7 @@ class PhononDos(MSONable):
             return wd2kt / np.tanh(wd2kt) - np.log(2 * np.sinh(wd2kt))
 
         # x*coth(x) - log(2*sinh(x)) diverges logarithmically as x -> 0, but g(omega) -> 0
-        entropy = np.trapezoid(_thermo_integrand(freqs, dens, entropy_weight, 0.0), x=freqs)
+        entropy = float(np.trapezoid(_thermo_integrand(freqs, dens, entropy_weight, None), x=freqs))
 
         entropy *= const.Boltzmann * const.Avogadro
 
@@ -349,7 +370,7 @@ class PhononDos(MSONable):
             return np.log(2 * np.sinh(wd2kt))
 
         # log(2*sinh(x)) diverges logarithmically as x -> 0, but g(omega) -> 0
-        e_free = np.trapezoid(_thermo_integrand(freqs, dens, free_energy_weight, 0.0), x=freqs)
+        e_free = float(np.trapezoid(_thermo_integrand(freqs, dens, free_energy_weight, None), x=freqs))
 
         e_free *= const.Boltzmann * const.Avogadro * temp
 

--- a/src/pymatgen/phonon/dos.py
+++ b/src/pymatgen/phonon/dos.py
@@ -18,12 +18,45 @@ if np.lib.NumpyVersion(np.__version__) < "2.0.0":
     np.trapezoid = np.trapz  # type:ignore[assignment]  # noqa: NPY201
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from typing import Self
 
     from numpy.typing import ArrayLike, NDArray
 
 BOLTZ_THZ_PER_K = const.value("Boltzmann constant in Hz/K") / const.tera  # Boltzmann constant in THz/K
 THZ_TO_J = const.value("hertz-joule relationship") * const.tera
+
+
+def _thermo_integrand(
+    freqs: NDArray, dens: NDArray, weight: Callable[[NDArray], NDArray], zero_freq_weight: float
+) -> NDArray:
+    """Build the integrand weight(freqs) * dens for a thermodynamic DOS integral.
+
+    NOTE: every Bose-Einstein weight below is singular at omega = 0 (0/0 for C_v and U,
+    log 0 for S and F), so evaluating it on a grid that samples omega = 0 exactly yields
+    nan and silently poisons the whole trapezoid. Frequency grids that start at exactly 0
+    are common: phonopy writes one whenever a DOS range is requested
+    (`phonopy --dos --dos-range="0 <max> <pitch>"`), and hand-built grids such as
+    `np.linspace(0, f_max, n)` do the same. Evaluating the weight only where omega > 0 and
+    substituting the analytic omega -> 0 limit keeps the integration domain intact.
+
+    Args:
+        freqs: non-negative frequencies, ascending.
+        dens: densities corresponding to freqs.
+        weight: the Bose-Einstein weight, evaluated only where freqs > 0.
+        zero_freq_weight: value used where freqs == 0. For C_v and U this is the exact
+            limit of the weight. For S and F the weight itself diverges logarithmically,
+            but the divergence is integrable and any physical phonon DOS vanishes as
+            omega -> 0 (g(omega) ~ omega^2), so the omega = 0 sample contributes nothing
+            and 0 is used.
+
+    Returns:
+        NDArray: the integrand, finite everywhere freqs and dens are finite.
+    """
+    weights = np.full_like(freqs, zero_freq_weight, dtype=float)
+    positive = freqs > 0
+    weights[positive] = weight(freqs[positive])
+    return weights * dens
 
 
 class PhononDos(MSONable):
@@ -194,11 +227,12 @@ class PhononDos(MSONable):
         freqs = self._positive_frequencies
         dens = self._positive_densities
 
-        def csch2(x):
-            return 1.0 / (np.sinh(x) ** 2)
+        def cv_weight(freq: NDArray) -> NDArray:
+            wd2kt = freq / (2 * BOLTZ_THZ_PER_K * temp)
+            return wd2kt**2 / np.sinh(wd2kt) ** 2
 
-        wd2kt = freqs / (2 * BOLTZ_THZ_PER_K * temp)
-        cv = np.trapezoid(wd2kt**2 * csch2(wd2kt) * dens, x=freqs)
+        # x**2 / sinh(x)**2 -> 1 as x -> 0
+        cv = np.trapezoid(_thermo_integrand(freqs, dens, cv_weight, 1.0), x=freqs)
         cv *= const.Boltzmann * const.Avogadro
 
         if structure:
@@ -231,8 +265,12 @@ class PhononDos(MSONable):
         freqs = self._positive_frequencies
         dens = self._positive_densities
 
-        wd2kt = freqs / (2 * BOLTZ_THZ_PER_K * temp)
-        entropy = np.trapezoid((wd2kt * 1 / np.tanh(wd2kt) - np.log(2 * np.sinh(wd2kt))) * dens, x=freqs)
+        def entropy_weight(freq: NDArray) -> NDArray:
+            wd2kt = freq / (2 * BOLTZ_THZ_PER_K * temp)
+            return wd2kt / np.tanh(wd2kt) - np.log(2 * np.sinh(wd2kt))
+
+        # x*coth(x) - log(2*sinh(x)) diverges logarithmically as x -> 0, but g(omega) -> 0
+        entropy = np.trapezoid(_thermo_integrand(freqs, dens, entropy_weight, 0.0), x=freqs)
 
         entropy *= const.Boltzmann * const.Avogadro
 
@@ -266,8 +304,13 @@ class PhononDos(MSONable):
         freqs = self._positive_frequencies
         dens = self._positive_densities
 
-        wd2kt = freqs / (2 * BOLTZ_THZ_PER_K * temp)
-        e_phonon = np.trapezoid(freqs * 1 / np.tanh(wd2kt) * dens, x=freqs) / 2
+        def internal_energy_weight(freq: NDArray) -> NDArray:
+            wd2kt = freq / (2 * BOLTZ_THZ_PER_K * temp)
+            return freq / np.tanh(wd2kt)
+
+        # omega*coth(omega/2kT) -> 2kT as omega -> 0
+        integrand = _thermo_integrand(freqs, dens, internal_energy_weight, 2 * BOLTZ_THZ_PER_K * temp)
+        e_phonon = float(np.trapezoid(integrand, x=freqs)) / 2
 
         e_phonon *= THZ_TO_J * const.Avogadro
 
@@ -301,8 +344,12 @@ class PhononDos(MSONable):
         freqs = self._positive_frequencies
         dens = self._positive_densities
 
-        wd2kt = freqs / (2 * BOLTZ_THZ_PER_K * temp)
-        e_free = np.trapezoid(np.log(2 * np.sinh(wd2kt)) * dens, x=freqs)
+        def free_energy_weight(freq: NDArray) -> NDArray:
+            wd2kt = freq / (2 * BOLTZ_THZ_PER_K * temp)
+            return np.log(2 * np.sinh(wd2kt))
+
+        # log(2*sinh(x)) diverges logarithmically as x -> 0, but g(omega) -> 0
+        e_free = np.trapezoid(_thermo_integrand(freqs, dens, free_energy_weight, 0.0), x=freqs)
 
         e_free *= const.Boltzmann * const.Avogadro * temp
 

--- a/tests/phonon/test_dos.py
+++ b/tests/phonon/test_dos.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+import warnings
 
 import numpy as np
 import orjson
@@ -72,14 +73,16 @@ class TestPhononDos(MatSciTest):
         assert dos.frequencies[0] == 0
         assert dos.ind_zero_freq == 0
 
-        for temp in (10, 300):
-            for value in (
-                dos.cv(temp),
-                dos.entropy(temp),
-                dos.internal_energy(temp),
-                dos.helmholtz_free_energy(temp),
-            ):
-                assert np.isfinite(value)
+        with warnings.catch_warnings():  # a vanishing g(0) must not warn
+            warnings.simplefilter("error")
+            for temp in (10, 300):
+                for value in (
+                    dos.cv(temp),
+                    dos.entropy(temp),
+                    dos.internal_energy(temp),
+                    dos.helmholtz_free_energy(temp),
+                ):
+                    assert np.isfinite(value)
 
         # the omega = 0 sample carries zero density, so dropping it must leave the
         # integrals unchanged up to the one trapezoid panel [0, delta] it spans
@@ -89,6 +92,35 @@ class TestPhononDos(MatSciTest):
         assert dos.internal_energy(300) == approx(trimmed.internal_energy(300), rel=1e-3)
         assert dos.helmholtz_free_energy(300) == approx(trimmed.helmholtz_free_energy(300), rel=1e-3)
         assert dos.zero_point_energy() == approx(trimmed.zero_point_energy(), rel=1e-3)
+
+    def test_thermodynamic_functions_warn_on_finite_zero_frequency_density(self):
+        """g(0) > 0 puts the DOS outside the harmonic model S and F assume, so warn.
+
+        C_v and U have finite omega -> 0 weight limits and stay exact, but the S and F
+        weights diverge logarithmically there. The divergence is integrable, so dropping
+        the omega = 0 sample still converges (verified below by refining the grid), but on
+        a coarse grid it under-integrates and the user should hear about it.
+        """
+        freqs = np.linspace(0, 10, 201)
+        dos = PhononDos(freqs, np.ones_like(freqs))  # diffusive-style VDOS, g(0) = 1
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            assert np.isfinite(dos.cv(300))
+            assert np.isfinite(dos.internal_energy(300))
+
+        for func in (dos.entropy, dos.helmholtz_free_energy):
+            with pytest.warns(UserWarning, match="non-zero density"):
+                assert np.isfinite(func(300))
+
+        # refining the grid converges rather than diverging
+        with pytest.warns(UserWarning, match="non-zero density"):
+            coarse = dos.entropy(300)
+        fine_freqs = np.linspace(0, 10, 6401)
+        with pytest.warns(UserWarning, match="non-zero density"):
+            fine = PhononDos(fine_freqs, np.ones_like(fine_freqs)).entropy(300)
+        assert coarse < fine
+        assert fine == approx(coarse, rel=0.02)
 
     def test_add(self):
         dos_2x = self.dos + self.dos

--- a/tests/phonon/test_dos.py
+++ b/tests/phonon/test_dos.py
@@ -58,6 +58,38 @@ class TestPhononDos(MatSciTest):
         assert self.dos.entropy(300, structure=self.structure) == approx(75.08543723748751, abs=1e-4)
         assert self.dos.zero_point_energy(structure=self.structure) == approx(4847.462485708741, abs=1e-4)
 
+    def test_thermodynamic_functions_with_zero_frequency_sample(self):
+        """Grids that sample omega = 0 exactly must not poison the integrals with nan.
+
+        phonopy writes such a grid whenever a DOS range is requested
+        (phonopy --dos --dos-range="0 <max> <pitch>"), and it is what
+        np.linspace(0, f_max, n) gives, so this is a common input to get_ph_dos.
+        """
+        n_pts = 401
+        freqs = np.linspace(0, 20, n_pts)
+        # Debye-like DOS: g(omega) ~ omega**2, vanishing at omega = 0 as any physical DOS must
+        dos = PhononDos(freqs, freqs**2)
+        assert dos.frequencies[0] == 0
+        assert dos.ind_zero_freq == 0
+
+        for temp in (10, 300):
+            for value in (
+                dos.cv(temp),
+                dos.entropy(temp),
+                dos.internal_energy(temp),
+                dos.helmholtz_free_energy(temp),
+            ):
+                assert np.isfinite(value)
+
+        # the omega = 0 sample carries zero density, so dropping it must leave the
+        # integrals unchanged up to the one trapezoid panel [0, delta] it spans
+        trimmed = PhononDos(freqs[1:], freqs[1:] ** 2)
+        assert dos.cv(300) == approx(trimmed.cv(300), rel=1e-3)
+        assert dos.entropy(300) == approx(trimmed.entropy(300), rel=1e-3)
+        assert dos.internal_energy(300) == approx(trimmed.internal_energy(300), rel=1e-3)
+        assert dos.helmholtz_free_energy(300) == approx(trimmed.helmholtz_free_energy(300), rel=1e-3)
+        assert dos.zero_point_energy() == approx(trimmed.zero_point_energy(), rel=1e-3)
+
     def test_add(self):
         dos_2x = self.dos + self.dos
         assert dos_2x.frequencies == approx(self.dos.frequencies)


### PR DESCRIPTION
## Summary

`PhononDos.cv`, `entropy`, `internal_energy` and `helmholtz_free_energy` return `nan` — silently, no exception — whenever the frequency grid samples `omega = 0` exactly.

All four integrate a Bose-Einstein weight against the DOS from the first non-negative frequency (`_positive_frequencies`, which includes 0). Each weight is singular there — `x**2/sinh(x)**2` and `omega*coth(omega/2kT)` are `0/0`, `log(2*sinh(x))` is `log 0` — so the integrand picks up a `nan` at the first sample and `np.trapezoid` propagates it to the result.

Grids that start at exactly 0 are not exotic. phonopy writes one whenever a DOS range is requested:

```console
$ phonopy --dos --dos-range="0 16 0.1"      # first row of total_dos.dat is 0.0000000 0.0000000
```

and `np.linspace(0, f_max, n)` gives the same thing, so `pymatgen.io.phonopy.get_ph_dos` hands `PhononDos` such a grid routinely. Reproducer, using phonopy's own bundled Si example (`example/Si`, 20x20x20 mesh) round-tripped through pymatgen's own reader:

```python
from pymatgen.io.phonopy import get_ph_dos

dos = get_ph_dos("total_dos.dat")
dos.frequencies[0], dos.densities[0]   # 0.0, 0.0  <- density vanishes, so the limit is finite
dos.cv(300)                            # nan  (before) -> 39.8298  (after)
dos.entropy(300)                       # nan  (before) -> 40.6312  (after)
dos.internal_energy(300)               # nan  (before) -> 18423.1  (after)
dos.helmholtz_free_energy(300)         # nan  (before) ->  6233.8  (after)
```

phonopy's own `run_thermal_properties` on the same force constants gives `C_v = 39.8354` and `S = 40.6827 J/K/mol-cell`, so the recovered values agree to 0.01% and 0.13% — the residual is ordinary DOS-sampling error, which is the point: nothing about `omega = 0` was ever physically singular here, the density vanishes there.

### Fix

Evaluate each weight only where `omega > 0` and substitute the analytic `omega -> 0` limit at the zero sample, so the integration domain is left intact:

- `C_v`: `x**2/sinh(x)**2 -> 1`
- `U`: `omega*coth(omega/2kT) -> 2kT`
- `S`, `F`: the weights have no finite limit — they diverge logarithmically. The divergence is integrable, so dropping the `omega = 0` sample converges to the correct integral, and it contributes exactly nothing for the harmonic lattice DOS these functions model (`g ~ omega**2` in 3D). A DOS with `g(0) > 0` — a VDOS from the velocity autocorrelation of a diffusive MD trajectory, say — is outside that model, so it warns rather than quietly under-integrating (per review).

Grids that do not sample `omega = 0` take an identical code path to before — the existing NaCl reference values in `test_thermodynamic_functions` are unchanged, byte for byte.

`zero_point_energy` was already immune (no division) and is untouched.

### Test

`test_thermodynamic_functions_with_zero_frequency_sample` builds a Debye-like DOS on `np.linspace(0, 20, 401)`, asserts all four functions are finite at 10 K and 300 K, and asserts they match the same DOS with the `omega = 0` sample dropped to within 1e-3 relative — i.e. the zero sample now contributes only its trapezoid panel, not a `nan`. It fails on `main` with `assert np.isfinite(nan)` and passes with the fix.

`test_thermodynamic_functions_warn_on_finite_zero_frequency_density` covers the `g(0) > 0` case: `C_v` and `U` stay silent and exact, `S` and `F` warn, and refining the grid 201 -> 6401 points moves `S` by 1.2% and keeps shrinking — i.e. the dropped sample converges rather than diverging.

## Human intent

Rephrased from the user's request:

- While auditing reproducibility of materials-science codes (phonopy, hiPhive, BoltzTraP2, CGCNN), review pymatgen for defects that those workflows would actually hit, and upstream a fix.
- Prefer a real, reproducible correctness bug with a fail-to-pass regression test over a documentation or style change.

## Checklist

- [x] Tests for the affected code pass locally (`uv run pytest tests/phonon tests/io/test_phonopy.py` — 75 passed, 21 skipped for the missing optional phonopy dep)
- [x] Lint passes: `uv run ruff check . && uv run ruff format --check .`

## Breaking changes?

- [ ] This PR contains **breaking changes**.

No behavior change for any grid that does not sample `omega = 0`; grids that do previously produced `nan`.
