### PR TITLE
Add typing for data_keys to fix mypy error

### DIFF
--- a/src/pymatgen/io/vasp/outputs.py
+++ b/src/pymatgen/io/vasp/outputs.py
@@ -4079,7 +4079,9 @@ class VolumetricData(BaseVolumetricData):
             file.write(lines)  # type:ignore[arg-type]
             dim = self.dim
 
-            data_keys = ("spin_up", "spin_down") if {"spin_up", "spin_down"}.issubset(self.data) else ("total",)
+            data_keys: tuple[str, ...] = (
+                ("spin_up", "spin_down") if {"spin_up", "spin_down"}.issubset(self.data) else ("total",)
+            )
             if self.is_soc:
                 data_keys = ("total", "diff_x", "diff_y", "diff_z")
             elif self.is_spin_polarized and data_keys == ("total",):


### PR DESCRIPTION
Tiny fix for this mypy error (that otherwise stops commits):
```
src\pymatgen\io\vasp\outputs.py:4084: error: Incompatible types in assignment (expression has type "tuple[str, str, str, str]", variable has type "tuple[str, str] | tuple[str]")  [assignment]
```
