### PR TITLE
Fix CHGCAR augmentation corruption from doubled newlines

### DIFF
--- a/src/pymatgen/io/vasp/outputs.py
+++ b/src/pymatgen/io/vasp/outputs.py
@@ -4026,8 +4026,10 @@ class VolumetricData(BaseVolumetricData):
             aug_data: Any = self.data_aug.get(data_type, {})
 
             if isinstance(aug_data, (list, tuple)):
+                # Legacy lines already carry their trailing newline; a second one corrupts the block.
                 for line in aug_data:
-                    file.write(f"{line}\n")
+                    text = str(line)
+                    file.write(text if text.endswith("\n") else f"{text}\n")
                 return
 
             if not isinstance(aug_data, dict):

--- a/tests/io/vasp/test_outputs.py
+++ b/tests/io/vasp/test_outputs.py
@@ -1751,6 +1751,31 @@ class TestChgcar(MatSciTest):
         assert "augmentation occupancies   1   3" in contents
         assert "0.1000000000E+01 0.2000000000E+01 0.3000000000E+01" in contents
 
+    def test_write_legacy_aug_lines_keep_their_own_newline(self):
+        # Legacy data_aug stores raw text lines that already end in "\n". Writing
+        # must not append a second one: a blank line inside an augmentation block
+        # makes VASP's RD_RHO_PAW declare the ion corrupt, discard the CHGCAR and
+        # silently fall back to an atomic density (ICHARG=1 degrades to 2).
+        legacy_aug = {
+            "total": [
+                "augmentation occupancies   1   3\n",
+                " 0.1000000000E+01 0.2000000000E+01 0.3000000000E+01 \n",
+            ]
+        }
+        chgcar = Chgcar(self.chgcar_no_spin.structure, self.chgcar_no_spin.data, data_aug=legacy_aug)
+        out_path = f"{self.tmp_path}/CHGCAR_legacy_aug_newlines"
+        chgcar.write_file(out_path)
+        contents = Path(out_path).read_text(encoding="utf-8")
+
+        aug_lines = contents[contents.index("augmentation occupancies") :].splitlines()
+        assert all(line.strip() for line in aug_lines), "blank line inside augmentation block"
+        assert aug_lines[0] == "augmentation occupancies   1   3"
+        assert aug_lines[1].split() == [
+            "0.1000000000E+01",
+            "0.2000000000E+01",
+            "0.3000000000E+01",
+        ]
+
     def test_soc_chgcar(self):
         assert set(self.chgcar_NiO_soc.data) == {
             "total",


### PR DESCRIPTION
## Summary

`VolumetricData.write_file` corrupts CHGCARs whose `data_aug` is in the legacy
list-of-lines format.

The legacy branch in `write_aug` appends a newline to lines that already end with
one:

```python
if isinstance(aug_data, (list, tuple)):
    for line in aug_data:
        file.write(f"{line}\n")
```

Legacy `data_aug` entries come straight from `for line in file` (the pre-rewrite
`parse_file` appended `original_line`), so they already carry their `\n`.

Thus, VASP prints

```
RD_RHO_PAW: ion            2 data corrupt
WARNING: PAW occupancies are missing on CHGCAR
```

to stdout when running with `ICHARG=1` and initializing with a CHGCAR file.

### Origin

Before the augmentation-parsing rewrite, this branch read:

```python
file.write("".join(data))
```

which was symmetric with a parser that stored lines *with* their trailing
newline. The rewrite replaced it with a per-line write that assumes *stripped*
lines. The new dict path is self-consistent, but the legacy branch is now wrong.

Bisected against released artifacts: correct in `pymatgen-core` 2026.4.16 and in
every earlier release checked back to `pymatgen` 2024.8.9; broken from 2026.5.17
onward.

### Fix

Write the newline only when the line does not already have one. Output is
byte-identical for already-stripped lines and for non-`str` entries, so callers
that worked around this by pre-stripping their `data_aug` are unaffected.

### A note on existing coverage

`test_write_preserves_legacy_aug_lines` already covers this branch, but its
fixture uses lines *without* trailing newlines — the one convention the broken
code handles correctly — so it passed before and after this change. That is why
the defect shipped despite nominal coverage. The added test uses the real legacy
format and asserts that no blank line appears inside an augmentation block; it
fails on `main` and passes with this change.

## Checklist

- [x] Tests for the affected code pass locally:
      `pytest tests/io/vasp/test_outputs.py tests/io/test_common.py`
      → 195 passed, 0 failed
- [x] Lint passes: `ruff check .` and `ruff format --check .`

## Breaking changes?

- [ ] This PR contains **breaking changes**
