### PR TITLE
Fix `SpacegroupAnalyzer.get_point_group_symbol()` for cells with non-conventional basis orientations

### DIFF
--- a/src/pymatgen/symmetry/analyzer.py
+++ b/src/pymatgen/symmetry/analyzer.py
@@ -197,11 +197,8 @@ class SpacegroupAnalyzer:
         Returns:
             Pointgroup: Point group for structure.
         """
-        rotations = self._space_group_data.rotations
-        # passing a 0-length rotations list to spglib can segfault
-        if len(rotations) == 0:
-            return "1"
-        return spglib.get_pointgroup(rotations)[0].strip()  # type:ignore[index]
+        # determined by spglib from the space group type, and so is basis-independent:
+        return self._space_group_data.pointgroup
 
     def get_crystal_system(self) -> CrystalSystem:
         """Get the crystal system for the structure, e.g. (triclinic, orthorhombic,

--- a/tests/symmetry/test_analyzer.py
+++ b/tests/symmetry/test_analyzer.py
@@ -91,6 +91,19 @@ class TestSpacegroupAnalyzer(MatSciTest):
         assert self.sg.get_point_group_symbol() == "mmm"
         assert self.disordered_sg.get_point_group_symbol() == "4/mmm"
 
+    def test_get_pointgroup_unaligned_supercell(self):
+        # point group determination is basis-independent, consistent with the space group type, including
+        # for supercells whose basis vectors are not aligned with the conventional cell axes
+        # (where some point operations are not expressible as integer matrices in the cell basis) --
+        # previously a failure case, when point-group determination was based on spglib rotations dataset
+        diamond = Structure.from_spacegroup("Fd-3m", Lattice.cubic(3.5597), ["C"], [[0, 0, 0]])
+        for sc_matrix in (3, [[2, 2, -1], [-1, 2, 2], [2, -1, 2]]):  # aligned & rotated 3a0 cubes
+            struct = diamond.copy()
+            struct.make_supercell(sc_matrix)
+            sga = SpacegroupAnalyzer(struct, symprec=0.01)
+            assert sga.get_space_group_symbol() == "Fd-3m"
+            assert sga.get_point_group_symbol() == "m-3m"
+
     def test_get_pearson_symbol(self):
         assert self.sg.get_pearson_symbol() == "oP24"
         assert self.disordered_sg.get_pearson_symbol() == "tP58"


### PR DESCRIPTION
## Summary
`SpacegroupAnalyzer.get_point_group_symbol()` currently determines the point group from `spglib`'s `dataset.rotations` (from `spglib.get_pointgroup()`). The `spglib` dataset only returns operations expressible as integer matrices in the input cell basis, so for structures described in a (super)cell whose basis vectors are not aligned with the conventional cell axes, part of the crystal's point operations are missing from `rotations`, and the method returns a lower symmetry point group (the expressible subgroup) as a result, which is inconsistent with `get_space_group_symbol()`, which instead uses spglib's basis-independent type identification.

MWE (pristine diamond in a rotated-cube 3x supercell):
```python
from pymatgen.core import Lattice, Structure
from pymatgen.symmetry.analyzer import SpacegroupAnalyzer

diamond = Structure.from_spacegroup("Fd-3m", Lattice.cubic(3.5597), ["C"], [[0, 0, 0]])
sc = diamond.copy()
sc.make_supercell([[2, 2, -1], [-1, 2, 2], [2, -1, 2]])  # 3a0 cube, edges along <221> axes
sga = SpacegroupAnalyzer(sc, symprec=0.01)
sga.get_space_group_symbol()  # "Fd-3m" (correct)
sga.get_point_group_symbol()  # "-3m"   (wrong; should be "m-3m")
```

Such mis-aligned supercells arise routinely from cell-shape optimisation in defect/phonon/MD workflows.

The fix is to directly return `dataset.pointgroup`, which `spglib` computes from the space-group type (basis-independent, as with `get_space_group_symbol()` -- now self-consistent) and which is already held in self._space_group_data. 

The `SpglibDataset.pointgroup` field is available throughout pymatgen's supported `spglib` range (>=2.5). A regression test covering both aligned and rotated diamond supercells (this MWE) is included.

## Checklist

- [x] Tests for the affected code pass locally (e.g. `uv run pytest tests/core -k lattice`
      for a lattice change — the full suite runs in CI)
- [x] Lint passes: `uv run ruff check . && uv run ruff format --check .`
