### PR TITLE
Add `symmetric` option to `group_structures`, pass through to `sm.fit()` and test

### DIFF
--- a/src/pymatgen/core/structure_matcher.py
+++ b/src/pymatgen/core/structure_matcher.py
@@ -840,7 +840,7 @@ class StructureMatcher(MSONable):
 
         return None
 
-    def group_structures(self, s_list, anonymous=False):
+    def group_structures(self, s_list, anonymous=False, symmetric=False):
         """
         Given a list of structures, use fit to group
         them by structural equality.
@@ -848,6 +848,13 @@ class StructureMatcher(MSONable):
         Args:
             s_list ([Structure]): List of structures to be grouped
             anonymous (bool): Whether to use anonymous mode.
+            symmetric (bool):
+                Whether a pair must match in both directions to be
+                grouped. Defaults to `False`. `fit()` is not symmetric
+                and the reference below is always passed as `struct1`,
+                so by default the grouping depends on the order of
+                `s_list`. Ignored if `anonymous` is `True`, since
+                `fit_anonymous` has no symmetric mode.
 
         Returns:
             A list of lists of matched structures
@@ -890,7 +897,7 @@ class StructureMatcher(MSONable):
                     )
                 else:
                     inds = filter(
-                        lambda i: self.fit(refs, unmatched[i][1], skip_structure_reduction=True),
+                        lambda i: self.fit(refs, unmatched[i][1], symmetric=symmetric, skip_structure_reduction=True),
                         list(range(len(unmatched))),
                     )
                 inds = list(inds)

--- a/tests/core/test_structure_matcher.py
+++ b/tests/core/test_structure_matcher.py
@@ -536,6 +536,20 @@ class TestStructureMatcher(MatSciTest):
         assert sm_coarse.fit(struct1, struct2, symmetric=True) is False
         assert sm_coarse.fit(struct2, struct1, symmetric=True) is False
 
+    def test_group_structures_symmetric(self):
+        """
+        `fit()` is directional and `group_structures` always passes its
+        reference as `struct1`, so by default the grouping depends on the order
+        of `s_list`. `symmetric=True` removes this order-dependence."""
+        sm = StructureMatcher(comparator=ElementComparator(), ltol=0.6, stol=0.6, angle_tol=6)
+        struct1 = Structure.from_file(f"{VASP_IN_DIR}/POSCAR_fit_symm_s1")
+        struct2 = Structure.from_file(f"{VASP_IN_DIR}/POSCAR_fit_symm_s2")
+
+        assert len(sm.group_structures([struct1, struct2])) == 1
+        assert len(sm.group_structures([struct2, struct1])) == 2
+        assert len(sm.group_structures([struct1, struct2], symmetric=True)) == 2
+        assert len(sm.group_structures([struct2, struct1], symmetric=True)) == 2
+
     def test_oxi(self):
         """Test oxidation state removal matching."""
         sm = StructureMatcher()


### PR DESCRIPTION
## Summary

This is a small PR to add the `symmetric` option to `StructureMatcher.group_structures()`, which is then passed through to the underlying `StructureMatcher.fit()` usage.

Summary with the help of Claude:
`StructureMatcher.fit` is directional; `symmetric=False` by default, and its docstring says so. But `group_structures` consumes it as if it were an equality test: it pops a reference and always passes that reference as `struct1`. So which structure happens to come first decides the grouping.

This repo already keeps a structure pair for the asymmetry, used by `test_fit`:
```python
# src/pymatgen/util/testing.py:36
VASP_IN_DIR: str = f"{TEST_FILES_DIR}/io/vasp/inputs"
```

```python
sm = StructureMatcher(comparator=ElementComparator(), ltol=0.6, stol=0.6, angle_tol=6)
s1 = Structure.from_file(f"{VASP_IN_DIR}/POSCAR_fit_symm_s1")
s2 = Structure.from_file(f"{VASP_IN_DIR}/POSCAR_fit_symm_s2")

len(sm.group_structures([s1, s2]))                   # 1 group
len(sm.group_structures([s2, s1]))                   # 2 groups   <-- same inputs
len(sm.group_structures([s1, s2], symmetric=True))   # 2 groups
len(sm.group_structures([s2, s1], symmetric=True))   # 2 groups
```

Using `test-files/io/vasp/inputs/POSCAR_fit_symm_s1` and `_s2`, from `tests/core/test_structure_matcher.py:529-537`.

This PR threads a `symmetric` kwarg through to the `fit` call so callers that need an order-independent
grouping can ask for one. It defaults to `False`, so no existing caller changes behaviour, and it is
ignored under `anonymous=True` since `fit_anonymous` has no symmetric mode. One test added.

**Motivation:** `MaterialsProjectDFTMixingScheme` groups GGA and r2SCAN structures this way, and the
asymmetry makes its phase diagrams depend on `PYTHONHASHSEED` — see materialsproject/pymatgen#3113 and
the follow-up PR (I'll be raising now) to materialsproject/pymatgen#4703, which passes `symmetric=True` here. Over the 120 permutations of the pre-group in that bug, the current default yields 3 distinct groupings and `symmetric=True` yields 1, at 1.04x runtime for the full pipeline.

Note this does not make greedy grouping order-independent in general — a symmetric relation can still be non-transitive — but it removes the directional class of it at least.

## Checklist

- [x] Tests for the affected code pass locally (e.g. `uv run pytest tests/core -k lattice`
      for a lattice change — the full suite runs in CI)
- [x] Lint passes: `uv run ruff check . && uv run ruff format --check .`

## Breaking changes?

- [ ] This PR contains **breaking changes** (removals/renames, signature or
      behavior changes, changed defaults/output, dropped Python versions, ...).
      If so, prefix the title with `[breaking]` and describe the change and
      migration steps under `## Breaking Changes` below.

## Breaking Changes

<!-- Optional. Copied verbatim into COMPATIBILITY.md at release time by
     `invoke update-changelog`. Be specific: what changed, what is affected,
     how to migrate. -->
