### PR TITLE
Avoid ``UFloat`` warning spam with mixed MP PDs

### DIFF
--- a/src/pymatgen/analysis/reaction_calculator.py
+++ b/src/pymatgen/analysis/reaction_calculator.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, overload
 import numpy as np
 from monty.fractions import gcd_float
 from monty.json import MontyDecoder, MSONable
-from uncertainties import UFloat, ufloat
+from uncertainties import UFloat, nominal_value, ufloat
 
 from pymatgen.core.composition import Composition
 from pymatgen.core.entries import ComputedEntry
@@ -484,12 +484,12 @@ class ComputedReaction(Reaction):
 
         for entry in self._reactant_entries + self._product_entries:
             comp, factor = entry.composition.get_reduced_composition_and_factor()
-            energy_ufloat = (
+            energy = (
                 ufloat(entry.energy, entry.correction_uncertainty)
                 if entry.correction_uncertainty and not np.isnan(entry.correction_uncertainty)
                 else entry.energy
-            )
-            calc_energies[comp] = min(calc_energies.get(comp, float("inf")), energy_ufloat / factor)
+            ) / factor  # ufloat energy divided by ``factor``
+            calc_energies[comp] = min(calc_energies.get(comp, energy), energy, key=nominal_value)
 
         ufloat_reaction_energy = self.calculate_energy(calc_energies)
         return ufloat_reaction_energy.std_dev if isinstance(ufloat_reaction_energy, UFloat) else np.nan

--- a/src/pymatgen/core/entries.py
+++ b/src/pymatgen/core/entries.py
@@ -30,7 +30,6 @@ from typing import TYPE_CHECKING, cast
 import numpy as np
 import orjson
 from monty.json import MontyDecoder, MontyEncoder, MSONable
-from uncertainties import ufloat
 
 from pymatgen.core.structure_matcher import SpeciesComparator, StructureMatcher
 
@@ -511,11 +510,7 @@ class ComputedEntry(Entry):
     @property
     def correction(self) -> float:
         """The total energy correction / adjustment applied to the entry in eV."""
-        # either sum of adjustments or ufloat with nan std_dev, so that no corrections still result in ufloat object:
-        corr = sum(ufloat(ea.value, ea.uncertainty) for ea in self.energy_adjustments if ea.value) or ufloat(
-            0.0, np.nan
-        )
-        return corr.nominal_value
+        return math.fsum(ea.value for ea in self.energy_adjustments)
 
     @correction.setter
     def correction(self, x: float) -> None:
@@ -530,16 +525,13 @@ class ComputedEntry(Entry):
     @property
     def correction_uncertainty(self) -> float:
         """The uncertainty of the energy adjustments applied to the entry in eV."""
-        # either sum of adjustments or ufloat with nan std_dev, so that no corrections still result in ufloat object:
-        unc = sum(
-            (ufloat(ea.value, ea.uncertainty) if not np.isnan(ea.uncertainty) and ea.value else ufloat(ea.value, 0))
-            for ea in self.energy_adjustments
-        ) or ufloat(0.0, np.nan)
-
-        if not math.isclose(unc.nominal_value, 0) and math.isclose(unc.std_dev, 0):
-            return np.nan
-
-        return unc.std_dev
+        # Quadrature sum of the (independent) adjustment uncertainties, skipping unknown (nan) ones and those of
+        # zero-valued adjustments:
+        quad_sum = math.hypot(
+            *(ea.uncertainty for ea in self.energy_adjustments if ea.value and not np.isnan(ea.uncertainty))
+        )
+        # A total of zero means no uncertainty information supplied, so return nan rather than implying exact certainty:
+        return quad_sum or np.nan
 
     @property
     def correction_uncertainty_per_atom(self) -> float:

--- a/tests/core/test_entries.py
+++ b/tests/core/test_entries.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import warnings
 from collections import defaultdict
 
+import numpy as np
 import pytest
 from pytest import approx
 
@@ -132,6 +134,17 @@ class TestComputedEntry:
         assert entry.correction_per_atom == approx(-4.5 / 15)
         assert entry.correction_uncertainty == approx(0.9)
         assert entry.correction_uncertainty_per_atom == approx(0.9 / 15)
+
+    def test_zero_uncertainty_adjustment_doesnt_warn(self):
+        """Adjustments with uncertainty=0 (e.g. the MP GGA(+U)/r2SCAN mixing adjustment attached to entries
+        from the Materials Project API) must not trigger "Using UFloat objects with std_dev==0" warnings.
+        """
+        entry = ComputedEntry("Fe6O9", 6.9, energy_adjustments=[ConstantEnergyAdjustment(-5, uncertainty=0)])
+        with warnings.catch_warnings():
+            warnings.filterwarnings("error", message="Using UFloat objects")
+            assert entry.correction == approx(-5)
+            assert entry.energy == approx(1.9)
+            assert np.isnan(entry.correction_uncertainty)  # zero uncertainty still means "unknown"
 
     def test_normalize(self):
         entry = ComputedEntry("Fe6O9", 6.9, correction=1)


### PR DESCRIPTION
## Summary

Follow-up to #4386 / #4400 / #4406, which left one case open: an energy adjustment that is present with `uncertainty == 0.0`.

`uncertainties>=3.2` warns inside the `ufloat()` constructor whenever `std_dev == 0` (`uncertainties/core.py:1024`). Materials Project entries carry `ConstantEnergyAdjustment("MP GGA(+U)/r2SCAN mixing adjustment", uncertainty=0.0)`
on every r2SCAN entry, so `ComputedEntry.correction` re-fires the warning on every `.energy` access.

MWE:
```python
from mp_api.client import MPRester
from pymatgen.analysis.phase_diagram import PhaseDiagram

with MPRester() as mpr:
    entries = mpr.get_entries_in_chemsys(["Cs", "Ti", "I"])
PhaseDiagram(entries)   # UserWarning: Using UFloat objects with std_dev==0 ...
```

`ufloat` is not needed in either property (correction or uncertainty) — correction only returns `.nominal_value`, and the uncertainty is a plain quadrature sum:

- `correction` -> `math.fsum(ea.value for ea in self.energy_adjustments)`
- `correction_uncertainty` -> `math.hypot(*(...)) or np.nan`  (i.e. `sum(uncertainty**2)**0.5`; quadrature sum)

Also folds in the same warning family in `analysis/reaction_calculator.py`:
`min(float, UFloat)` fell through to the deprecated `AffineScalarFunc.__lt__`, emitting `FutureWarning` from `test_calculated_reaction_energy_uncertainty`. Now compares on `nominal_value`, which also removes the `float("inf")` sentinel.

All existing tests pass, plus new `test_zero_uncertainty_adjustment_doesnt_warn` here. `ComputedEntry.energy` is also now ~20x faster (20k accesses: 0.059 s -> 0.003 s)(e.g. `PhaseDiagram` construction, which uses many `.energy` accesses).

## Checklist

- [x] Tests for the affected code pass locally (e.g. `uv run pytest tests/core -k lattice`
      for a lattice change — the full suite runs in CI)
- [ ] Lint passes: `uv run ruff check . && uv run ruff format --check .`

## Breaking changes?

- [ ] This PR contains **breaking changes** (removals/renames, signature or
      behavior changes, changed defaults/output, dropped Python versions, ...).
      If so, prefix the title with `[breaking]` and describe the change and
      migration steps under `## Breaking Changes` below.
